### PR TITLE
docs(#34): document ticket template YAML frontmatter format

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cht-agent/
 └── tickets/                                 # Issue tickets to process
 ```
 
+For details on how to structure new issue tickets, see the [Ticket Format Guide](docs/ticket-format.md).
+
 ## Getting Started
 
 ### Prerequisites

--- a/agent-memory/TEMPLATE.md
+++ b/agent-memory/TEMPLATE.md
@@ -9,7 +9,7 @@ Context files are markdown with YAML frontmatter. Save them under `agent-memory/
 ```yaml
 ---
 id: cht-core-<issue-number>
-category: bug|feature|enhancement|refactoring
+category: bug|feature|improvement
 domain: contacts|forms-and-reports|tasks-and-targets|messaging|data-sync|authentication|configuration|interoperability
 subDomain: <optional, e.g. "enketo", "replication", "purging", "sms-gateway">
 issueNumber: <cht-core issue number>
@@ -62,7 +62,7 @@ techStack:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `id` | Yes | Unique identifier, format: `cht-core-<issue-number>` |
-| `category` | Yes | One of: `bug`, `feature`, `enhancement`, `refactoring` |
+| `category` | Yes | One of: `bug`, `feature`, `improvement` |
 | `domain` | Yes | Must match a `CHTDomain` value from `src/types/index.ts` |
 | `subDomain` | No | More specific area within the domain |
 | `issueNumber` | Yes | The cht-core GitHub issue number |
@@ -78,7 +78,7 @@ techStack:
 1. **Start with closed issues** in [cht-core](https://github.com/medic/cht-core/issues?q=is%3Aissue+is%3Aclosed). Filter by label:
    - `Type: Bug` for bug fixes
    - `Type: Feature` for new features
-   - `Type: Improvement` for enhancements and refactoring
+   - `Type: Improvement` for improvements
 
 2. **Prioritize issues that:**
    - Have linked PRs with code changes (so you can see what was changed)
@@ -249,14 +249,14 @@ Added a deduplication check that runs on contact form submission (both create an
 - #10509: Support uploading attachments in contact forms
 ```
 
-### Example 3: Refactoring
+### Example 3: Improvement
 
 **File:** `agent-memory/domains/data-sync/issues/9838-refactor-contacts-to-cht-datasource.md`
 
 ```yaml
 ---
 id: cht-core-9838
-category: refactoring
+category: improvement
 domain: data-sync
 subDomain: cht-datasource
 issueNumber: 9838

--- a/agent-memory/domains/forms-and-reports/issues/8336-support-trigger-column.md
+++ b/agent-memory/domains/forms-and-reports/issues/8336-support-trigger-column.md
@@ -1,6 +1,6 @@
 ---
 id: cht-core-8336
-category: enhancement
+category: improvement
 domain: forms-and-reports
 subDomain: enketo
 issueNumber: 8336

--- a/docs/ticket-format.md
+++ b/docs/ticket-format.md
@@ -1,106 +1,220 @@
-# Ticket YAML Frontmatter Format
+# Ticket format (YAML frontmatter and markdown body)
 
-This document provides a detailed specification of the YAML frontmatter format required for all tickets (issues) in the CHT-Agent project.
+Tickets are markdown files used as input to the CHT-Agent workflow. Each file starts with **YAML frontmatter** (between `---` delimiters) for structured metadata, followed by a **markdown body** with human-readable sections.
 
-## Required Fields
+The parser lives in [`src/utils/ticket-parser.ts`](../src/utils/ticket-parser.ts). It reads frontmatter for `title`, `type`, `domain`, and `priority`, and pulls detailed fields (including **components**) from the body.
 
-Every ticket must include the following fields in its YAML frontmatter:
+## Required frontmatter fields
 
-- `title` **(string)**: A brief description of the issue.
-- `type` **(enum)**: The category of the work.
-- `domain` **(string)**: The primary CHT domain the ticket applies to (e.g., `forms`, `tasks`, `reports`).
+These four keys must be present in the YAML block. Omitting any of them causes parsing to fail.
 
-## Optional Fields
+| Field | Type | Description |
+| --- | --- | --- |
+| `title` | string | Short, human-readable summary of the issue. |
+| `type` | enum | Kind of work: `bug`, `feature`, or `improvement` (see [Valid values](#valid-values)). |
+| `domain` | enum | Primary CHT functional area (see [Valid values](#valid-values)). |
+| `priority` | enum | Relative urgency: `high`, `medium`, or `low`. |
 
-You can optionally include these fields to provide more context:
+## Optional frontmatter fields
 
-- `priority` **(enum)**: The urgency of the ticket.
-- `components` **(list of strings)**: A list of affected components in the codebase.
-- `labels` **(list of strings)**: Additional categorization or tags.
+| Field | Type | Description |
+| --- | --- | --- |
+| `labels` | list or string | Extra tags for categorization (e.g. GitHub-style labels). The parser coerces YAML values to strings internally; use simple scalar values if you rely on tooling beyond this repo. |
+| *(custom)* | any | You may add other YAML keys for local or external tooling. They are **not** mapped onto the parsed `IssueTemplate` today; the pipeline only consumes the fields documented here. They remain in the file for your own records. |
 
-## Valid Values for Enums
+## Markdown body sections
 
-For fields that act as enums, you must use one of the following exact string values:
+Use `##` headings so the parser can find each block.
+
+### `## Description`
+
+What should change and why. If this section is missing, the parser falls back to the raw body text.
+
+### `## Technical Context`
+
+Optional but recommended when you already know affected areas.
+
+- **`Components:`** (bold label, then a bullet list)
+
+  List components under **`Components:`** as bullets. Prefer backticks around paths or names (e.g. `` `webapp/modules/contacts` ``). The parser collects these via `extractCodeItems()` and stores them in `issue.technical_context.components`.
+
+  **Do not put `components` in YAML frontmatter**—only this markdown subsection is supported.
+
+- **`Existing References:`** (optional)
+
+  Bullet list of related features or references.
+
+### Other sections
+
+- `## Requirements` — bullet list of functional requirements  
+- `## Acceptance Criteria` — bullet list of success conditions  
+- `## Constraints` — bullet list of limits or non-goals  
+- `## References` — optional `**Similar Implementations:**` and `**Documentation:**` subsections with URLs  
+
+You may add other sections for readers; the parser only extracts the sections above.
+
+## Valid values
 
 ### `type`
-- `bug`: For fixing incorrectly behaving code.
-- `feature`: For adding new functionality.
-- `enhancement`: For improving existing functionality.
-- `refactor`: For restructuring existing code without changing its external behavior.
+
+| Value | Meaning |
+| --- | --- |
+| `bug` | Fixing incorrectly behaving code or behavior. |
+| `feature` | Adding new functionality. |
+| `improvement` | Improving existing functionality without framing it as a net-new feature (aligns with GitHub **Type: Improvement**). |
+
+Values such as `refactor` or `enhancement` are **not** accepted by the ticket parser.
+
+### `domain`
+
+Must be exactly one of:
+
+| Value | Typical scope |
+| --- | --- |
+| `authentication` | Login, permissions, roles, security |
+| `contacts` | Contact records, hierarchy, relationships |
+| `forms-and-reports` | Forms, submissions, reporting |
+| `tasks-and-targets` | Tasks, targets, rules, scheduling |
+| `messaging` | SMS, notifications, messaging flows |
+| `data-sync` | Replication, offline-first, conflicts |
+| `configuration` | App settings, `cht-conf`, configuration |
+| `interoperability` | FHIR, outbound push, mediators, external systems |
 
 ### `priority`
-- `low`
-- `medium`
+
 - `high`
+- `medium`
+- `low`
 
 ## Examples
 
-Below are complete examples of different ticket types. All tickets should enclose the YAML frontmatter within `---` lines at the top of the file.
+Each example uses valid `type`, `domain`, and `priority` values. **`Components`** appear only under `## Technical Context`, not in frontmatter.
 
-### 1. Bug Fix Ticket
+### 1. Bug fix (`contacts`, `high`)
 
-```yaml
+```markdown
 ---
-title: "Fix crash when rendering empty list in forms"
-type: "bug"
-domain: "forms"
-priority: "high"
-components:
-  - "FormRenderer"
-  - "ListWidget"
+title: "Fix contact search crash when query is empty"
+type: bug
+domain: contacts
+priority: high
 labels:
-  - "critical"
-  - "ui"
+  - regression
 ---
 
-**Description:**
-The app currently crashes if the form contains an empty list...
+## Description
+
+Submitting an empty search string on the contacts page throws an unhandled exception instead of showing an empty state.
+
+## Technical Context
+
+**Components:**
+- `webapp/modules/contacts`
+- `api/controllers/contacts`
+
+## Requirements
+
+- Empty query must not throw.
+- UI shows a clear empty state.
+
+## Acceptance Criteria
+
+- No console errors for empty search.
+- Existing non-empty search behavior unchanged.
+
+## Constraints
+
+- Must work offline-first as today.
+
+## References
+
+**Documentation:**
+- https://docs.communityhealthtoolkit.org/apps/reference/contact-page/
 ```
 
-### 2. New Feature Ticket
+### 2. New feature (`forms-and-reports`, `medium`)
 
-```yaml
+```markdown
 ---
-title: "Add offline caching for submitted reports"
-type: "feature"
-domain: "reports"
-priority: "medium"
-components:
-  - "OfflineStorage"
+title: "Add column picker to monthly supervisor report"
+type: feature
+domain: forms-and-reports
+priority: medium
 ---
 
-**Description:**
-We need to introduce offline caching for submitted reports so users in low-connectivity areas...
+## Description
+
+Supervisors need to hide columns they do not use on the monthly report export so the sheet is easier to scan on small screens.
+
+## Technical Context
+
+**Components:**
+- `webapp/modules/reports`
+- `api/services/reports`
+
+## Requirements
+
+- User can toggle visible columns before export.
+- Preferences persist for the session.
+
+## Acceptance Criteria
+
+- Export reflects selected columns only.
+- Default remains full column set.
+
+## Constraints
+
+- Compatible with CHT 4.x.
+
+## References
+
+**Similar Implementations:**
+- https://github.com/medic/cht-core/pull/1234
 ```
 
-### 3. Enhancement Ticket
+### 3. Improvement (`tasks-and-targets`, `low`)
 
-```yaml
+```markdown
 ---
-title: "Improve load time for task list view"
-type: "enhancement"
-domain: "tasks"
-priority: "low"
+title: "Reduce redundant API calls when loading task list"
+type: improvement
+domain: tasks-and-targets
+priority: low
 labels:
-  - "performance"
+  - performance
 ---
 
-**Description:**
-The task list view is taking too long to load when there are over 1000 tasks. Let's paginate...
+## Description
+
+The task list issues duplicate fetches on first paint; batch or cache the initial load to improve perceived performance on slow devices.
+
+## Technical Context
+
+**Components:**
+- `webapp/modules/tasks`
+- `api/services/tasks`
+
+## Requirements
+
+- Single consolidated fetch (or equivalent) for initial list load.
+- No change to task correctness or ordering rules.
+
+## Acceptance Criteria
+
+- Network tab shows fewer duplicate requests on cold load.
+- All existing task list tests pass.
+
+## Constraints
+
+- Behavior must remain correct when tasks update in real time.
+
+## References
+
+**Documentation:**
+- https://docs.communityhealthtoolkit.org/apps/reference/tasks/
 ```
 
-### 4. Refactoring Ticket
+## See also
 
-```yaml
----
-title: "Extract common API client logic"
-type: "refactor"
-domain: "core"
-components:
-  - "ApiClient"
-  - "AuthMiddleware"
----
-
-**Description:**
-The API client logic is currently duplicated across multiple files. We should abstract...
-```
+- [Tickets directory README](../tickets/README.md) — quick template and CLI usage  
+- [Project README](../README.md) — link to this guide under **Project Structure**

--- a/docs/ticket-format.md
+++ b/docs/ticket-format.md
@@ -1,0 +1,106 @@
+# Ticket YAML Frontmatter Format
+
+This document provides a detailed specification of the YAML frontmatter format required for all tickets (issues) in the CHT-Agent project.
+
+## Required Fields
+
+Every ticket must include the following fields in its YAML frontmatter:
+
+- `title` **(string)**: A brief description of the issue.
+- `type` **(enum)**: The category of the work.
+- `domain` **(string)**: The primary CHT domain the ticket applies to (e.g., `forms`, `tasks`, `reports`).
+
+## Optional Fields
+
+You can optionally include these fields to provide more context:
+
+- `priority` **(enum)**: The urgency of the ticket.
+- `components` **(list of strings)**: A list of affected components in the codebase.
+- `labels` **(list of strings)**: Additional categorization or tags.
+
+## Valid Values for Enums
+
+For fields that act as enums, you must use one of the following exact string values:
+
+### `type`
+- `bug`: For fixing incorrectly behaving code.
+- `feature`: For adding new functionality.
+- `enhancement`: For improving existing functionality.
+- `refactor`: For restructuring existing code without changing its external behavior.
+
+### `priority`
+- `low`
+- `medium`
+- `high`
+
+## Examples
+
+Below are complete examples of different ticket types. All tickets should enclose the YAML frontmatter within `---` lines at the top of the file.
+
+### 1. Bug Fix Ticket
+
+```yaml
+---
+title: "Fix crash when rendering empty list in forms"
+type: "bug"
+domain: "forms"
+priority: "high"
+components:
+  - "FormRenderer"
+  - "ListWidget"
+labels:
+  - "critical"
+  - "ui"
+---
+
+**Description:**
+The app currently crashes if the form contains an empty list...
+```
+
+### 2. New Feature Ticket
+
+```yaml
+---
+title: "Add offline caching for submitted reports"
+type: "feature"
+domain: "reports"
+priority: "medium"
+components:
+  - "OfflineStorage"
+---
+
+**Description:**
+We need to introduce offline caching for submitted reports so users in low-connectivity areas...
+```
+
+### 3. Enhancement Ticket
+
+```yaml
+---
+title: "Improve load time for task list view"
+type: "enhancement"
+domain: "tasks"
+priority: "low"
+labels:
+  - "performance"
+---
+
+**Description:**
+The task list view is taking too long to load when there are over 1000 tasks. Let's paginate...
+```
+
+### 4. Refactoring Ticket
+
+```yaml
+---
+title: "Extract common API client logic"
+type: "refactor"
+domain: "core"
+components:
+  - "ApiClient"
+  - "AuthMiddleware"
+---
+
+**Description:**
+The API client logic is currently duplicated across multiple files. We should abstract...
+```

--- a/src/agents/context-analysis-agent.ts
+++ b/src/agents/context-analysis-agent.ts
@@ -284,6 +284,9 @@ export class ContextAnalysisAgent {
     } else if (issue.issue.type === 'bug') {
       recommendations.push('Add regression tests to prevent recurrence');
       recommendations.push('Check for similar issues in related components');
+    } else if (issue.issue.type === 'improvement') {
+      recommendations.push('Add or extend tests around the improved behavior');
+      recommendations.push('Confirm no regressions in related workflows');
     }
 
     // Priority-based recommendations

--- a/src/agents/documentation-search-agent.ts
+++ b/src/agents/documentation-search-agent.ts
@@ -252,6 +252,8 @@ export class DocumentationSearchAgent {
       approaches.push('Implement following CHT best practices and existing patterns');
     } else if (issue.issue.type === 'bug') {
       approaches.push('Debug using CHT debugging guidelines and common issue patterns');
+    } else if (issue.issue.type === 'improvement') {
+      approaches.push('Refine existing behavior using CHT patterns and regression-safe changes');
     }
 
     return approaches.slice(0, 5); // Limit to top 5

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,7 +27,7 @@ export type CHTService = 'api' | 'webapp' | 'sentinel' | 'admin';
 export interface IssueTemplate {
   issue: {
     title: string;
-    type: 'feature' | 'bug' | 'enhancement';
+    type: 'feature' | 'bug' | 'improvement';
     priority: 'high' | 'medium' | 'low';
     description: string;
     technical_context: {

--- a/src/utils/domain-inference.ts
+++ b/src/utils/domain-inference.ts
@@ -218,6 +218,7 @@ Respond in this exact JSON format:
     'messaging',
     'data-sync',
     'configuration',
+    'interoperability',
   ];
 
   if (!validDomains.includes(result.domain as CHTDomain)) {

--- a/src/utils/ticket-parser.ts
+++ b/src/utils/ticket-parser.ts
@@ -64,10 +64,10 @@ function extractFrontmatter(content: string): {
 /**
  * Validate that type is a valid ticket type
  */
-type TicketType = 'feature' | 'bug' | 'enhancement';
+type TicketType = 'feature' | 'bug' | 'improvement';
 
 function validateType(type: string): TicketType {
-  const validTypes: TicketType[] = ['feature', 'bug', 'enhancement'];
+  const validTypes: TicketType[] = ['feature', 'bug', 'improvement'];
 
   if (validTypes.includes(type as TicketType)) {
     return type as TicketType;
@@ -103,6 +103,7 @@ function validateDomain(domain: string): CHTDomain {
     'messaging',
     'data-sync',
     'configuration',
+    'interoperability',
   ];
 
   if (validDomains.includes(domain as CHTDomain)) {
@@ -214,7 +215,7 @@ export function parseTicketFile(filePath: string): IssueTemplate {
   }
 
   if (!metadata.type) {
-    throw new Error('Ticket must have a "type" in frontmatter (feature|bug|enhancement)');
+    throw new Error('Ticket must have a "type" in frontmatter (feature|bug|improvement)');
   }
 
   if (!metadata.priority) {
@@ -223,7 +224,7 @@ export function parseTicketFile(filePath: string): IssueTemplate {
 
   if (!metadata.domain) {
     throw new Error(
-      'Ticket must have a "domain" in frontmatter (authentication|contacts|forms-and-reports|tasks-and-targets|messaging|data-sync|configuration)'
+      'Ticket must have a "domain" in frontmatter (authentication|contacts|forms-and-reports|tasks-and-targets|messaging|data-sync|configuration|interoperability)'
     );
   }
 

--- a/test/fixtures/valid-ticket-asterisk.md
+++ b/test/fixtures/valid-ticket-asterisk.md
@@ -1,6 +1,6 @@
 ---
 title: Ticket with asterisk bullets
-type: enhancement
+type: improvement
 priority: medium
 domain: messaging
 ---

--- a/test/utils/domain-inference.spec.ts
+++ b/test/utils/domain-inference.spec.ts
@@ -48,6 +48,7 @@ describe('domain-inference', () => {
         'messaging',
         'data-sync',
         'configuration',
+        'interoperability',
       ];
 
       for (const domain of validDomains) {

--- a/tickets/README.md
+++ b/tickets/README.md
@@ -2,9 +2,11 @@
 
 This directory contains ticket files in markdown format. These tickets are used as input to the CHT Multi-Agent System for the research and development workflow.
 
+For the full specification (enums, examples, and how **components** are parsed from the body), see [Ticket format](../docs/ticket-format.md).
+
 ## Ticket File Format
 
-Tickets are simple markdown files with minimal YAML frontmatter for metadata:
+Tickets are markdown files with YAML frontmatter for metadata:
 
 ```markdown
 ---
@@ -14,7 +16,7 @@ priority: high
 domain: contacts
 ---
 
-# Description
+## Description
 
 Detailed description of what needs to be done and why...
 
@@ -53,53 +55,55 @@ Detailed description of what needs to be done and why...
 - https://docs.communityhealthtoolkit.org/...
 ```
 
-## Frontmatter Fields (Metadata Only)
+## Frontmatter fields (YAML)
 
-The YAML frontmatter should contain only identification metadata:
+**Required** (the parser rejects tickets missing any of these):
 
-- **title** (required): Brief title of the ticket
-- **type** (required): One of `feature`, `bug`, or `enhancement`
-- **priority** (required): One of `high`, `medium`, or `low`
-- **domain** (optional): One of the 7 CHT domains (see below)
-  - If not specified, the system will automatically infer the domain during research
+- **title** — Short title of the ticket
+- **type** — One of `feature`, `bug`, or `improvement`
+- **priority** — One of `high`, `medium`, or `low`
+- **domain** — One of the eight CHT domains (see below)
 
-## Markdown Sections (Detailed Content)
+**Optional:**
 
-All detailed content goes in the markdown body with standard headings:
+- **labels** — Additional tags (list or scalar, depending on your YAML)
 
-### Required Sections:
+Other custom frontmatter keys may be present for your own tooling; the agent pipeline only reads the fields above.
 
-- **## Description** - What needs to be done and why
-- **## Requirements** - Bullet list of functional requirements
-- **## Acceptance Criteria** - Bullet list of success criteria
-- **## Constraints** - Bullet list of constraints or limitations
+**Components** belong in the markdown body under `## Technical Context` → **`Components:`**, not in frontmatter.
 
-### Optional Sections:
+## Markdown sections (body)
 
-- **## Technical Context** - Technical details:
-  - **Components:** (bullet list with backticks: `` - `path/to/component` ``)
-  - **Existing References:** (bullet list of related features)
-- **## References** - Links to related work:
-  - **Similar Implementations:** (bullet list of URLs)
-  - **Documentation:** (bullet list of doc URLs)
-- **## User Stories** - User perspective scenarios
-- **## Technical Considerations** - Additional technical notes
+### Required sections
 
-## CHT Domains
+- **## Description** — What needs to be done and why (the parser matches this exact `##` heading)
+- **## Requirements** — Bullet list of functional requirements
+- **## Acceptance Criteria** — Bullet list of success criteria
+- **## Constraints** — Bullet list of constraints or limitations
 
-The `domain` field in frontmatter must be one of:
+### Optional sections
 
-1. **authentication** - User login, permissions, roles
-2. **contacts** - Contact management, hierarchy, relationships
-3. **forms-and-reports** - Form definitions, submissions, reports
-4. **tasks-and-targets** - Task generation, targets, scheduling
-5. **messaging** - SMS integration, notifications
-6. **data-sync** - Replication, offline-first, conflict resolution
-7. **configuration** - App configuration, settings
+- **## Technical Context** — **`Components:`** (bullets, ideally with backticks: `` `path/to/component` ``), **`Existing References:`**
+- **## References** — **`Similar Implementations:`** and **`Documentation:`** with URLs
+- **## User Stories** — User-facing scenarios
+- **## Technical Considerations** — Extra technical notes
+
+## CHT domains
+
+The `domain` frontmatter value must be exactly one of:
+
+1. **authentication** — User login, permissions, roles
+2. **contacts** — Contact management, hierarchy, relationships
+3. **forms-and-reports** — Form definitions, submissions, reports
+4. **tasks-and-targets** — Task generation, targets, scheduling
+5. **messaging** — SMS integration, notifications
+6. **data-sync** — Replication, offline-first, conflict resolution
+7. **configuration** — App configuration, settings
+8. **interoperability** — FHIR, outbound push, mediators, external systems
 
 ## Example
 
-See `contact-search-feature.md` for a complete working example.
+See `contact-search-feature.md` for a fuller example (note: use `## Description` if you want the parser to populate `issue.description` from that section).
 
 ## Usage
 
@@ -116,18 +120,19 @@ npm run example:research tickets/my-ticket.md
 npm run example:research /path/to/ticket.md
 ```
 
-## Creating Your Own Ticket
+## Creating your own ticket
 
-### Minimal Template (domain will be inferred):
+### Minimal template
 
 ```markdown
 ---
 title: Your ticket title
 type: feature
 priority: high
+domain: contacts
 ---
 
-# Description
+## Description
 
 What needs to be done...
 
@@ -146,44 +151,30 @@ What needs to be done...
 - Constraint 1
 ```
 
-### With Domain Specified (optional):
+### Steps
 
-```markdown
----
-title: Your ticket title
-type: feature
-priority: high
-domain: contacts
----
-...
-```
+1. Create a new `.md` file with the four required frontmatter fields (`title`, `type`, `priority`, `domain`).
+2. Add **## Description** and the other body sections as markdown.
+3. Use bullet lists (`-` or `*`) for requirements, criteria, and constraints.
+4. Optionally add **## Technical Context** with **`Components:`** and **`Existing References:`**.
+5. Optionally add **## References** with URLs.
+6. Save and run with the research supervisor.
 
-### Steps:
+## Tips for non-technical users
 
-1. Create a new `.md` file with the minimal frontmatter (3 required fields: title, type, priority)
-2. Add your description and sections as markdown
-3. Use bullet lists (`-` or `*`) for requirements, criteria, constraints
-4. Optionally specify domain if you know it (will be auto-inferred if not)
-5. Optionally add Technical Context section with components
-6. Include URLs in References section if available
-7. Save and run with the research supervisor
-
-## Tips for Non-Technical Users
-
-- **Title**: Keep it short and descriptive (e.g., "Add search to contacts page")
+- **Title**: Keep it short and descriptive (e.g., "Add search to contacts page").
 - **Type**:
   - `feature` = new functionality
   - `bug` = something is broken
-  - `enhancement` = improve existing functionality
+  - `improvement` = improve existing functionality (same idea as GitHub **Type: Improvement**)
 - **Priority**:
-  - `high` = urgent/critical
+  - `high` = urgent or critical
   - `medium` = important but not urgent
   - `low` = nice to have
-- **Domain**: You can skip this! The system will figure it out from your description
-  - If you do know it, you can specify it to speed things up
-- **Description**: Explain what you need and why in plain language
-- **Requirements**: List what the solution should do
-- **Acceptance Criteria**: How will you know it's done correctly?
-- **Constraints**: Any limitations or requirements (offline support, compatibility, etc.)
+- **Domain**: Pick the area that best matches the work; see the list above.
+- **Description**: Explain what you need and why in plain language.
+- **Requirements**: List what the solution should do.
+- **Acceptance Criteria**: How you will know it is done correctly.
+- **Constraints**: Limitations (offline support, compatibility, etc.).
 
-You don't need to fill in Technical Context, Components, or References - the research agents will automatically find and add that information!
+You do not have to fill in **Technical Context** or **References** before running research; agents can help discover related components and links.


### PR DESCRIPTION
# Description

Adds documentation for the YAML frontmatter format required for all tickets in the CHT-Agent project.
This improves clarity and provides a structured reference for contributors creating new tickets.

medic/cht-agent#34