### PR TITLE
fix(#83): default MCP_SERVER_URL to dev Kapa AI endpoint

### DIFF
--- a/src/agents/documentation-search-agent.ts
+++ b/src/agents/documentation-search-agent.ts
@@ -15,11 +15,13 @@ import {
 
 export class DocumentationSearchAgent {
   private useMockMCP: boolean;
+  private mcpServerUrl: string;
 
-  constructor(options: { modelName?: string; useMockMCP?: boolean } = {}) {
+  constructor(options: { modelName?: string; useMockMCP?: boolean; mcpServerUrl?: string } = {}) {
     // Model will be used when MCP integration is complete
     // For now, we use mocked responses
     this.useMockMCP = options.useMockMCP !== false; // Default to true for POC
+    this.mcpServerUrl = options.mcpServerUrl ?? process.env.MCP_SERVER_URL ?? 'https://mcp-docs.dev.medicmobile.org/mcp';
   }
 
   /**
@@ -70,6 +72,8 @@ export class DocumentationSearchAgent {
     if (this.useMockMCP) {
       return this.mockKapaAIResponse(query, domain);
     }
+
+    console.log(`[Documentation Search Agent] Calling MCP server: ${this.mcpServerUrl}`);
 
     // TODO: Actual MCP implementation when server is ready
     // const mcpCall: MCPToolCall = {

--- a/src/cli/research.ts
+++ b/src/cli/research.ts
@@ -73,7 +73,7 @@ async function main() {
     console.log('🤖 Initializing Research Supervisor...\n');
     const supervisor = new ResearchSupervisor({
       modelName: 'claude-sonnet-4-20250514',
-      useMockMCP: true, // Using mocked MCP for now
+      useMockMCP: false, // Use real MCP by default 
     });
 
     // Display issue details


### PR DESCRIPTION
# Description
Default MCP_SERVER_URL to https://mcp-docs.dev.medicmobile.org/mcp when not explicitly set.
Added console.log to display the MCP server URL being used when the documentation search agent makes a call.

medic/cht-agent#83

# Code review checklist
- [x] Readable: Concise, well named, follows the style guide, documented if necessary.
- [ ] Documented: Configuration and user documentation on cht-docs
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.