### PR TITLE
chore(#16): recommendation document for test environment layer

### DIFF
--- a/designs/CHT Hierarchical Multi-Agent System PoC.md
+++ b/designs/CHT Hierarchical Multi-Agent System PoC.md
@@ -49,11 +49,13 @@ flowchart TB
     ContextLayer[Code Context Layer<br/>Local context files]
     HC1{{"HUMAN CHECKPOINT #1<br/>Validate research findings<br/>Approve orchestration plan"}}
     Dev[Development Supervisor]
-    CodeGen[Code Generation Layer<br/>Claude Code CLI / Claude API]
-    TestGen[Test Generation Layer<br/>Unit, Integration, E2E tests]
+    CodeGen[Code Generation Layer<br/>Claude Code CLI / Claude API<br/>self-check lint/tsc]
+    TestGen[Test Generation Layer<br/>Unit, Integration, E2E tests<br/>self-check lint/tsc]
+    Validation[Code Validation Layer<br/>ESLint, tsc, Prettier<br/>deterministic gate + retry]
+    Review[LLM Review<br/>score vs requirements / acceptance criteria]
     QA[QA Supervisor]
-    Validation[Code Validation Layer<br/>ESLint, Shellcheck]
-    TestOrch[Test Orchestration Layer<br/>npm scripts, Mocha/Jest]
+    TestEnv[Test Environment Layer<br/>build/start/seed CHT instance]
+    TestOrch[Test Orchestration Layer<br/>run tests, verify, coverage]
     HC2{{"HUMAN CHECKPOINT #2<br/>Review generated code<br/>Verify test results<br/>Approve for completion"}}
 
     CLI --> Master
@@ -65,11 +67,13 @@ flowchart TB
     HC1 --> Dev
     Dev --> CodeGen
     Dev --> TestGen
-    CodeGen --> QA
-    TestGen --> QA
-    QA --> Validation
-    QA --> TestOrch
-    Validation --> HC2
+    CodeGen --> Validation
+    TestGen --> Validation
+    Validation -->|fail| CodeGen
+    Validation -->|pass| Review
+    Review --> QA
+    QA --> TestEnv
+    TestEnv --> TestOrch
     TestOrch --> HC2
 ```
 
@@ -99,10 +103,16 @@ flowchart TB
 
 > **Note**: Tools like DeepWiki can be used separately to auto-generate code documentation (architecture docs, component diagrams) which can then feed into the context layer.
 
+> **Layer placement update (2026-06-05):** Per the [Test Environment Layer discovery findings](https://github.com/medic/cht-agent/issues/16#issuecomment-4238272374), two layers moved between supervisors and one was added:
+> - **Test Environment Layer** moved from Development → **QA Supervisor** (the QA Supervisor needs a running CHT instance to do its work; the Development Supervisor only produces code and tests).
+> - **Code Validation Layer** moved from QA → **Development Supervisor** as a deterministic gate that runs *before* an LLM Review step, looping failures back to Code Generation without spending LLM tokens.
+> - **LLM Review** added under the Development Supervisor (score generated code against requirements / acceptance criteria).
+> - Code Generation and Test Generation agents now **self-check lint/tsc** (like a developer running `npm run lint` before pushing) to catch trivial issues before the gate.
+
 ### Development Supervisor Layers
 
 #### Code Generation Layer
-**Purpose**: Generate code following CHT patterns and standards
+**Purpose**: Generate code following CHT patterns and standards. Self-checks lint/tsc before handing off.
 
 | Pluggable Options | Notes |
 |-------------------|-------|
@@ -113,7 +123,7 @@ flowchart TB
 | Cursor / Windsurf | IDE-based alternatives |
 
 #### Test Generation Layer
-**Purpose**: Write tests following CHT testing patterns
+**Purpose**: Write tests following CHT testing patterns. Self-checks lint/tsc before handing off.
 
 | Test Type | Description | Tools |
 |-----------|-------------|-------|
@@ -123,29 +133,36 @@ flowchart TB
 
 Based on [CHT Automated Tests documentation](https://docs.communityhealthtoolkit.org/community/contributing/code/core/automated-tests/).
 
-#### Test Environment Layer
-**Purpose**: Set up test data and environments
+#### Code Validation Layer
+**Purpose**: Static analysis and standards compliance — a deterministic gate run against the generated code before LLM Review. On failure, the structured errors loop back to Code Generation (max retries) without spending LLM tokens. See [Code Validation Layer recommendation](../layer_recommendations/code-validation-layer.md).
 
 | Pluggable Options | Notes |
 |-------------------|-------|
-| **cht-conf** | Configuration compilation |
-| **cht-toolbox** | Utility functions |
-| **cht-datasource** | Data pipeline configs |
-| k3d/Docker | Container orchestration for integration tests |
+| **ESLint** | JavaScript/TypeScript linting (against target project's config) |
+| **TypeScript (tsc)** | Type checking against target's per-directory tsconfig |
+| **Prettier** | Conditional — only when target project uses it |
+| **Shellcheck** | Shell script validation (`.sh` files only) |
+| CHT coding standards | Pattern matching against existing code |
+
+#### LLM Review
+**Purpose**: Score the generated code against the ticket's requirements and acceptance criteria once it has passed the deterministic Code Validation gate. Only validated code reaches this step.
 
 ### QA Supervisor Layers
 
-#### Code Validation Layer
-**Purpose**: Static analysis and standards compliance
+#### Test Environment Layer
+**Purpose**: Provide a live, configured, data-populated CHT instance the QA Supervisor can test against. Deterministic orchestration of existing tools — no LLM. See [Test Environment Layer recommendation](../layer_recommendations/test-environment-layer.md).
 
 | Pluggable Options | Notes |
 |-------------------|-------|
-| **ESLint** | JavaScript/TypeScript linting |
-| **Shellcheck** | Shell script validation |
-| CHT coding standards | Pattern matching against existing code |
+| **cht-core `scripts/docker-helper/cht-docker-compose.sh`** | Target repo's own helper — published-version bring-up, network/env/stop/destroy |
+| **`npm run local-images`** | Build images from local code changes (hybrid hot-reload for api/sentinel) |
+| **cht-conf** | Config compilation/upload, user creation, doc seeding |
+| **cht-conf-test-harness** | Config-level tests (tasks/targets/forms) without a full instance |
+| **cht-datasource** | Typed read/verify of seeded data |
+| CHT API / CouchDB API | Config discovery, data seeding, verification |
 
 #### Test Orchestration Layer
-**Purpose**: Run tests and analyze coverage
+**Purpose**: Run tests and analyze coverage against the environment the Test Environment Layer provides.
 
 | Pluggable Options | Notes |
 |-------------------|-------|

--- a/designs/layer_recommendations/test-environment-layer.md
+++ b/designs/layer_recommendations/test-environment-layer.md
@@ -1,0 +1,340 @@
+# Test Environment Layer — Recommendation Document
+
+**Issue:** [medic/cht-agent#16](https://github.com/medic/cht-agent/issues/16)
+**Status:** Draft
+**Date:** 2026-04-13
+
+---
+
+## Summary
+
+The Test Environment Layer is responsible for providing the QA Supervisor with a ready, configured, data-populated CHT environment. It is not responsible for test execution, verification, or reporting. Those belong to the QA Supervisor's Test Orchestration Layer ([#18](https://github.com/medic/cht-agent/issues/18)).
+
+The layer's contract: **"I give you a healthy CHT environment with the right config and test data. You tell me when to reset or tear it down."**
+
+### Architectural Placement
+
+The Test Environment Layer sits under the **QA Supervisor**, alongside Test Orchestration. It acts as the first step in the QA workflow: before tests can run or manual verification can happen, there must be a live CHT instance.
+
+```
+QA Supervisor
+├── Test Environment Layer     ← set up environment, config, test data
+└── Test Orchestration Layer   ← run tests, manual QA, verification
+```
+
+### Scope Boundaries
+
+| In Scope | Out of Scope |
+|----------|-------------|
+| Build Docker images from local code | Running tests (Test Orchestration) |
+| Start/stop/reset containers | Browser automation (Test Orchestration) |
+| Health check and readiness polling | Pass/fail judgment (QA Supervisor) |
+| Config discovery from running instance | Reporting and evidence collection (QA Supervisor) |
+| Test data generation and seeding | Test execution strategy (Test Orchestration) |
+| CLI interface for independent invocation | Code validation/linting (Code Validation Layer) |
+
+---
+
+## Three Responsibilities
+
+### 1. Environment Lifecycle
+
+Manage the full lifecycle of a local CHT instance built from source.
+
+#### Bootstrap Sequence
+
+```
+1. Build images     →  npm run local-images (in cht-core directory)
+2. Start containers →  docker compose -f cht-couchdb.yml -f cht-core.yml up -d
+3. Wait for ready   →  Poll /api/v2/monitoring until healthy
+4. Upload config    →  cht-conf --url=<url> compile-app-settings upload-app-settings
+5. Prepare data     →  Seed contacts, reports, users (see Responsibility #3)
+6. Signal ready     →  Return environment handle to QA Supervisor
+```
+
+#### `npm run local-images`
+
+The primary mechanism for building Docker images from local source code. Produces branch-specific image tags and generates compose files in `local-build/`. This is the correct foundation because it tests the actual code changes in a production-like environment.
+
+```bash
+# In cht-core directory
+npm run local-images
+
+# Start the environment
+cd local-build
+COUCHDB_PASSWORD=password docker compose -f cht-couchdb.yml -f cht-core.yml up -d
+```
+
+#### Readiness Strategy
+
+CHT requires multiple services to initialize (HAProxy, API, CouchDB, Sentinel). The layer must confirm the environment is usable before signaling ready.
+
+**Primary approach:** Poll `GET /api/v2/monitoring` with exponential backoff until a successful response. This is the same approach used by cht-conf's e2e test utilities ([cht-docker-utils.js](https://github.com/medic/cht-conf/blob/main/test/e2e/cht-docker-utils.js)).
+
+```typescript
+// Pseudocode
+const waitForReady = async (url: string, maxWaitMs = 120_000): Promise<void> => {
+  const start = Date.now();
+  let delay = 2_000;
+
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      const res = await fetch(`${url}/api/v2/monitoring`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await sleep(delay);
+    delay = Math.min(delay * 1.5, 15_000);
+  }
+
+  throw new Error(`CHT did not become ready within ${maxWaitMs}ms`);
+};
+```
+
+**Supplementary checks:**
+- `docker ps` to confirm all expected containers are running (nginx, sentinel, api, haproxy, healthcheck, couchdb)
+- `GET /api/v1/settings` to confirm the API is serving config (not just accepting connections)
+
+#### Reset Mechanism
+
+Between test runs, the environment needs to return to a known state. Three strategies, in order of preference:
+
+| Strategy | Speed | Isolation | When to Use |
+|----------|-------|-----------|-------------|
+| **CouchDB wipe + reseed** | Fast (~10s) | Good | Between test cases within a session |
+| **Container restart** | Medium (~30-60s) | Better | Between test suites or after config changes |
+| **Full teardown + rebuild** | Slow (~3-5min) | Complete | Between tickets or after code changes |
+
+The default should be **container restart** as a balance of speed and isolation. Full teardown is reserved for when the code under test has changed (new images needed).
+
+```bash
+# Quick reset: restart containers, reseed data
+docker compose restart
+# wait for readiness again
+# reseed test data
+
+# Full teardown
+docker compose down -v
+# rebuild if needed
+docker compose up -d
+```
+
+#### Teardown
+
+```bash
+docker compose -f cht-couchdb.yml -f cht-core.yml down -v
+```
+
+The `-v` flag removes volumes to ensure clean state. The layer should always teardown on completion or failure to avoid orphaned containers.
+
+### 2. Config Discovery
+
+Connect to a running CHT instance and discover its deployed configuration. This enables the layer to generate test data that is valid for the specific deployment.
+
+#### Data Sources
+
+| Endpoint | Data Retrieved |
+|----------|---------------|
+| `GET /api/v1/settings` | `contact_types` (hierarchy), `roles`, `permissions`, `transitions`, task/target config |
+| `GET /api/v1/forms` | List of installed forms (returns array of filenames) |
+| `GET /api/v1/forms/{id}.xml` | Individual form definitions |
+| CouchDB `_all_docs` | Existing documents for reference |
+
+#### Discovery Flow
+
+```typescript
+// Pseudocode
+const discoverConfig = async (url: string, auth: string) => {
+  const settings = await fetch(`${url}/api/v1/settings`, { headers: { Authorization: auth } });
+  const forms = await fetch(`${url}/api/v1/forms`, { headers: { Authorization: auth } });
+
+  return {
+    contactTypes: settings.contact_types,   // hierarchy structure
+    roles: settings.roles,                   // user types (online/offline)
+    permissions: settings.permissions,       // role-permission mapping
+    transitions: settings.transitions,       // enabled server-side transitions
+    forms: forms,                            // installed form list
+  };
+};
+```
+
+#### Why Config-Driven?
+
+The QA layer must work with **any** CHT deployment, not just a hardcoded assumed structure. Different deployments have different hierarchies, roles, and forms. Generating test data that doesn't match the deployed config will produce false failures.
+
+### 3. Test Data Preparation
+
+Generate and upload test data that conforms to the discovered configuration.
+
+#### Tools
+
+| Tool | Purpose | Invocation |
+|------|---------|------------|
+| **cht-conf** `csv-to-docs` | Convert CSV → JSON documents | `cht csv-to-docs` then `cht upload-docs` |
+| **cht-conf** `create-users` | Create user accounts from CSV | `cht create-users` (reads `users.csv`) |
+| **cht-conf** `compile-app-settings` | Compile and upload app config | `cht compile-app-settings upload-app-settings` |
+| **CHT API** | Direct document creation | `POST /api/v1/people`, `POST /api/v1/places` |
+| **CouchDB API** | Bulk document operations | `POST /medic/_bulk_docs` |
+| **cht-datasource** | Typed data access (read/verify) | `@medic/cht-datasource` remote adapter |
+
+#### Programmatic cht-conf Invocation
+
+Based on the existing pattern in [cht-core's test utilities](https://github.com/medic/cht-core/blob/master/tests/utils/cht-conf.js):
+
+```typescript
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const execAsync = promisify(exec);
+
+const runChtConf = async (action: string, cwd: string, url: string) => {
+  const chtConfPath = path.resolve(process.cwd(), './node_modules/.bin/cht');
+  const { stdout } = await execAsync(
+    `${chtConfPath} --url=${url} ${action} --force --accept-self-signed-certs --debug`,
+    { cwd }
+  );
+  return stdout;
+};
+```
+
+#### Data Generation Strategy
+
+1. Read discovered config (`contact_types`, `roles`, `forms`)
+2. Generate a valid hierarchy (places at each level, people assigned to places)
+3. Create users with appropriate roles
+4. Generate reports that match installed form definitions
+5. Upload via cht-conf or CHT API
+
+The data must be **minimal but complete**: enough to exercise the feature under test without unnecessary volume.
+
+#### cht-conf-test-harness
+
+For testing CHT app configurations (tasks, targets, contact summaries, forms) **without a full CHT instance**, [`cht-conf-test-harness`](https://github.com/medic/cht-conf-test-harness) provides a lightweight alternative:
+
+```javascript
+const Harness = require('cht-conf-test-harness');
+const harness = new Harness();
+
+await harness.start();
+await harness.setNow('2026-01-15');
+const tasks = await harness.getTasks();
+await harness.stop();
+```
+
+This is useful when the Test Generation agent produces config-level tests (task logic, target calculations) that don't require a full environment. The Test Environment Layer should detect when `cht-conf-test-harness` is sufficient and skip full environment setup.
+
+---
+
+## Tool Capabilities Matrix
+
+| Tool | Environment Lifecycle | Config Discovery | Test Data Prep | Notes |
+|------|----------------------|-----------------|----------------|-------|
+| `npm run local-images` | Build images from local code | - | - | Foundation for testing code changes |
+| `docker compose` | Start/stop/reset containers | - | - | Lifecycle management |
+| CHT API (`/api/v1/*`) | Health check (`/v2/monitoring`) | Settings, forms | Create contacts, reports | Primary programmatic interface |
+| `cht-conf` | - | - | Upload config, create users, seed docs | CLI tool, invoke via child_process |
+| `cht-conf-test-harness` | Simulates CHT (no Docker) | - | Embedded test data | Config-level tests only (tasks, targets, forms) |
+| `cht-toolbox` | - | - | Replicate docs between instances | Copy contacts/hierarchies from existing environments ([repo](https://github.com/jkuester/chtoolbox)) |
+| `cht-datasource` | - | - | Read/verify data (remote adapter) | Typed API for data access (CHT 4.18.0+) |
+| CouchDB API | - | - | Bulk doc operations | Direct database access for seeding/cleanup |
+
+---
+
+## CLI Interface
+
+The layer should be independently callable via `npm run test-env`, following the same pattern as `npm run research <ticket>` for the Research Supervisor. This enables:
+- Manual QA workflows from Claude Code containers
+- Overnight refactor testing where Claude can trigger environment setup independently
+- Standalone environment management without running the full cht-agent pipeline
+
+### Usage
+
+```bash
+# Full setup: build from local code, start, discover config, seed data
+npm run test-env -- --cht-core-path /path/to/cht-core
+
+# Use a specific CHT version from Docker Hub instead of building from source
+npm run test-env -- --version 4.18.0
+
+# Teardown a running environment
+npm run test-env -- --teardown
+
+# Reset to clean state (restart containers, reseed data)
+npm run test-env -- --reset
+```
+
+The primary command (`npm run test-env -- --cht-core-path ...`) runs the full bootstrap sequence: build images, start containers, wait for readiness, discover config, seed test data, and print the environment URL and credentials. This is the equivalent of `npm run research <ticket>` but for environment setup.
+
+### LangGraph Node Interface
+
+When called as part of the cht-agent pipeline, the layer exposes the same capabilities through a LangGraph node:
+
+```typescript
+interface TestEnvironmentState {
+  chtCorePath?: string;        // path to cht-core with code changes
+  version?: string;            // CHT version to use (if not building from source)
+  environmentUrl?: string;     // URL of running instance (output)
+  environmentAuth?: string;    // auth credentials (output)
+  config?: DiscoveredConfig;   // discovered configuration (output)
+  status: 'idle' | 'starting' | 'ready' | 'error' | 'teardown';
+  error?: string;
+}
+```
+
+---
+
+## Industry Context
+
+Research into how other multi-agent software development systems handle test environments reveals a clear pattern: **production systems universally separate environment setup from agent logic**.
+
+| System | Approach |
+|--------|----------|
+| SWE-Agent | SWE-ReX runtime abstraction (shared service, Docker-based) |
+| Devin | Pre-configured Devbox sandbox (infrastructure layer) |
+| OpenHands | Workspace SDK package (modular, pluggable backends) |
+| Amazon Q | Devfile declarations (configuration-as-code) |
+| MetaGPT, ChatDev | Implicit (not modeled, assumed to exist) |
+
+The common pattern is that environment management is a **service** that testing agents consume, not a step that a testing agent performs itself. Our design follows the same principle: the Test Environment Layer provides the service, the Test Orchestration Layer consumes it.
+
+---
+
+## Integration with QA Supervisor Workflow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     QA Supervisor                        │
+│                                                         │
+│  1. Test Environment Layer                              │
+│     ├── Build images (npm run local-images)             │
+│     ├── Start containers (docker compose up)            │
+│     ├── Wait for readiness (/api/v2/monitoring)         │
+│     ├── Discover config (/api/v1/settings, /forms)      │
+│     ├── Seed test data (cht-conf, CHT API)              │
+│     └── Signal ready → environment handle               │
+│                          │                              │
+│  2. Test Orchestration Layer                            │
+│     ├── Run unit tests (npm test)                       │
+│     ├── Run integration tests (against live CHT)        │
+│     ├── Run e2e tests (WebdriverIO)                     │
+│     ├── Manual QA verification                          │
+│     └── Coverage analysis (nyc)                         │
+│                          │                              │
+│  3. Signal complete → reset or teardown                 │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Open Questions
+
+1. **Docker-in-Docker:** If cht-agent runs inside a container (e.g., Claude Code container), can it reliably run `docker compose`? May need Docker socket mounting or sibling container patterns.
+
+2. **Resource constraints:** `npm run local-images` builds multiple Docker images. Minimum specs per CHT docs: 8GB RAM, 50GB disk, 4 cores. How do we handle environments where this isn't available?
+
+3. **Caching strategy:** Building images from source is slow. Can we cache built images per git SHA and skip rebuilds when the code hasn't changed?
+
+4. **Parallel environments:** Can we run multiple CHT instances (different ports) for parallel test runs? This matters for the Master Supervisor if it processes multiple tickets concurrently.
+
+5. **cht-conf-test-harness scope:** When should the layer use the lightweight harness instead of a full Docker environment? Need heuristics based on what the Test Generation agent produced (config tests vs integration tests vs e2e tests).

--- a/designs/layer_recommendations/test-environment-layer.md
+++ b/designs/layer_recommendations/test-environment-layer.md
@@ -306,15 +306,19 @@ Our design matches this: the Test Environment Layer is the service; the QA Super
 
 ## Implementation Plan (the step-by-step for #66 + #43)
 
-> Detailed in the working plan; summarized here so the doc is self-contained.
+> Detailed in the working plan; summarized here so the doc is self-contained. The mock-mode agent and its tests are **#43**; all real orchestration is **#66**.
 
-- **Phase 0 — Scaffolding & types.** Add `TestEnvironmentState`, `DiscoveredConfig`, environment-handle types to `src/types/index.ts`. Stub `src/agents/test-environment-agent.ts` with a **mock mode** mirroring the other agents (this is what #43 tests). Add `test-env` npm script + `src/cli/test-env.ts`.
-- **Phase 1 — Lifecycle (Model A).** Build + run + seed the **already-present** cht-core working copy (build via `local-images`; for standalone/published use `cht-docker-compose.sh`) + thin compose override to join `cht-agent-net`. Readiness polling (`/api/v2/monitoring`), phase gates for the human-gated rebuild, three-tier reset, teardown. **No clone, no hot-reload, no spike** — the working copy is an input (see Precondition).
-- **Phase 2 — Config discovery.** `/api/v1/settings` + `/forms` parsing into `DiscoveredConfig`.
-- **Phase 3 — Test data prep.** cht-conf child_process wrappers, config-driven generation, harness shortcut detection.
-- **Phase 4 — Handle + LangGraph node + CLI.** Write handle file; wire the node into the QA Supervisor graph; finish the standalone CLI.
-- **Phase 5 — Mock tests (#43).** `test/agents/test-environment-agent.spec.ts`: constructor/init, mock-mode structure, config generation, fixture generation, error handling — no real LLM, no real Docker.
-- **Phase 6 (later) — PR-review mode & sandbox container.** `--pr` flow; port the PoC `.devcontainer` security layers.
+- **#43 (DONE) — Mock-mode agent + tests.** (Agent + spec land together, per repo convention.)
+  - Types in `src/types/index.ts`: `DiscoveredConfig` (+ `ContactTypeConfig`, `RoleConfig`, `TransitionConfig`), `ProvisionOptions`, `EnvironmentHandle`, `TestDataResult`, `ResetTier`.
+  - `src/agents/test-environment-agent.ts` with **mock mode** mirroring the other agents — six methods (`provision`, `applyConfig`, `discoverConfig`, `prepareTestData`, `reset`, `teardown`): mock paths return cloned fixtures, real mode throws "not yet implemented".
+  - `src/agents/test-environment-agent.mock-data.ts` fixtures; `test/agents/test-environment-agent.spec.ts`.
+  - **Not in #43:** real Docker, the CLI, the LangGraph node, `TestEnvironmentState`.
+- **#66 — real orchestration** (fills in each method's real path):
+  - **Phase 1 — Lifecycle (Model A).** Build + run + seed the **already-present** cht-core working copy (build via `local-images`; for standalone/published use `cht-docker-compose.sh`) + thin compose override to join `cht-agent-net`. Readiness polling (`/api/v2/monitoring`), phase gates for the human-gated rebuild, three-tier reset, teardown. **No clone, no hot-reload, no spike** — the working copy is an input (see Precondition).
+  - **Phase 2 — Config discovery.** Real `/api/v1/settings` + `/forms` parsing into `DiscoveredConfig`.
+  - **Phase 3 — Test data prep.** cht-conf child_process wrappers, config-driven generation, harness shortcut detection.
+  - **Phase 4 — Handle + LangGraph node + CLI.** Add `TestEnvironmentState`; write the handle file; wire the node into the QA Supervisor graph; add the `npm run test-env` CLI (`src/cli/test-env.ts`).
+- **#66+ (later) — PR-review mode & sandbox container.** `--pr` flow; port the PoC `.devcontainer` security layers.
 - **Deferred — Model B hot-reload.** Containerize cht-core's `run-watch` (needs its own spike). Only after Model A is working end-to-end.
 
 ---

--- a/designs/layer_recommendations/test-environment-layer.md
+++ b/designs/layer_recommendations/test-environment-layer.md
@@ -21,7 +21,7 @@ The "walk into a secure room and bounce off the walls until tests pass" behaviou
 | **Layer identity** | Deterministic provisioning service consumed by the *already-containerized* cht-agent | No LLM in this layer. Iteration intelligence lives in the QA Supervisor, which runs in the cht-agent container. |
 | **Code iteration model** | **Model A — rebuild-on-change** | Agent edits the working copy → human-gated `local-images` rebuild → restart. cht-core has **no in-container hot-reload** today, so the live-mount "Model B" is deferred. No spike for this build. |
 | **PR-review mode** | **Design now, build later** | Interfaces and flow are specified here; implementation lands after the internal-pipeline path. |
-| **Sandbox** | **Replicate the PoC's 5-layer git/credential sandbox**, around the cht-agent container | Claude can run autonomous loops in the room with no remote/credential access. |
+| **Sandbox** | **PoC 5-layer git/credential sandbox**, around the cht-agent container | Claude runs autonomous loops with **read-only** remote access (public repos), **no write credentials, no Docker socket**, and a hard push block — only the host user pushes. |
 
 ---
 
@@ -76,7 +76,7 @@ The Development Supervisor's **Test Generation Layer** *writes* test code. This 
 ```
 
 **Why this shape:**
-- **No docker-in-docker.** The cht-agent does not build/run Docker inside itself. Either the host operator brings services up (PoC model, human-gated) or the cht-agent uses a **mounted host Docker socket** to manage *sibling* containers. Both keep us out of DinD. The recommendation is to start with the human-gated host model and treat the socket-mount as an opt-in convenience (see [Open Questions](#open-questions)).
+- **No docker-in-docker, and no Docker socket.** The cht-agent does not run Docker at all. The **host operator** brings services up (human-gated). A mounted host Docker socket was considered and **rejected** — it grants host-root (see [Sandbox Model](#sandbox-model-adapted-from-the-poc) and the resolved note in [Open Questions](#open-questions)).
 - **Shared network** means the agent reaches CHT at a stable hostname (e.g. `https://nginx` / `https://haproxy`) with no port juggling.
 - **Shared code volume** (host ↔ cht-agent container) is the working copy the agent edits and the host builds from. Under **Model A** (chosen), code changes reach the running CHT env via a rebuild (`local-images`), *not* a live mount into api/sentinel. Live-mount hot-reload (Model B) is a deferred optimization — see [Code-iteration model](#code-iteration-model-the-re-test-problem).
 
@@ -90,6 +90,63 @@ This layer **orchestrates the target repo's own launch tooling** rather than shi
 | `npm run local-images` + generated `local-build/` compose | **Local-code bring-up.** Builds branch-tagged images from the working copy so the agent tests *its own* changes. Used for the internal pipeline. |
 
 cht-agent contributes only a **thin compose override** that joins the running stack to `cht-agent-net` so the agent container can reach the services. The override layers on top of the target repo's compose files via `docker compose -f <target> -f <override>`. The `CHT_NETWORK` variable the helper already exposes is the seam we attach to. (A future Model B override would additionally mount source into api/sentinel for hot-reload.)
+
+---
+
+## Internal Pipeline Flow (where this layer fits, and where humans gate)
+
+The cht-agent runs on a ticket template. The dockerized agent clones cht-core (read-only — public repo), branches off `main` locally, runs the agentic layers to complete the ticket, and invokes this layer when it needs a live environment. Docker and remote `git push` are **human-only**.
+
+```mermaid
+flowchart TB
+    Ticket([ticket template])
+
+    subgraph Master["Master Supervisor"]
+      Checkout["clone cht-core (read-only)<br/>git checkout -b cht-agent/&lt;ticket&gt; — local, off main"]
+    end
+
+    subgraph Research["Research Supervisor — built (POC)"]
+      Doc[Documentation Search] --> Code[Code Context] --> Ctx[Context Analysis] --> Plan[Generate Plan]
+    end
+
+    HC1{{"HUMAN CHECKPOINT #1<br/>approve research &amp; plan"}}
+
+    subgraph Dev["Development Supervisor — not started"]
+      Gen["Code Generation<br/>(self-check lint/tsc)"] --> TGen[Test Generation]
+      TGen --> Val["Code Validation gate<br/>eslint / tsc / prettier"]
+      Val -->|fail| Gen
+      Val -->|pass| Rev[LLM Review]
+    end
+
+    subgraph QA["QA Supervisor — not started"]
+      subgraph TEL["Test Environment Layer — #43 mock done / #66 real"]
+        Prov[provision] --> Apply[applyConfig] --> Disc[discoverConfig] --> Seed[prepareTestData]
+      end
+      Seed --> Orch["Test Orchestration<br/>run tests, verify"]
+    end
+
+    HGate{{"HUMAN GATE — env bring-up<br/>npm run local-images + docker compose up<br/>(agent runs NO docker)"}}
+    HC2{{"HUMAN CHECKPOINT #2<br/>review code &amp; test results"}}
+    Push[["host user pushes / opens PR<br/>(agent reads remote, never pushes)"]]
+
+    Ticket --> Checkout --> Doc
+    Plan --> HC1 --> Gen
+    Rev --> Prov
+    Prov -. "request bring-up,<br/>poll /api/v2/monitoring" .-> HGate
+    HGate -. "healthy on cht-agent-net" .-> Prov
+    Orch --> HC2 --> Push
+
+    classDef human fill:#ffe8cc,stroke:#d9480f,color:#000;
+    class HC1,HC2,HGate,Push human;
+```
+
+**Human-involvement points (orange):**
+
+1. **Bootstrap clone** — read-only. The agent (or operator) clones the public cht-core and makes a **local** branch off `main`; it never pushes.
+2. **HUMAN CHECKPOINT #1** — after Research: approve findings + plan before any code is generated.
+3. **HUMAN GATE — env bring-up** — inside this layer's `provision`: the agent *requests* the environment and polls `/api/v2/monitoring`; the **human** runs `local-images` + `docker compose up` (the agent runs no Docker — a mounted socket would be host-root). CouchDB-tier resets are the exception — the agent does those over the CouchDB HTTP API.
+4. **HUMAN CHECKPOINT #2** — after QA: review generated code + test results.
+5. **Push** — only the host user pushes / opens the PR; the agent has read-only remote access and a hard push block.
 
 ---
 
@@ -274,17 +331,17 @@ This layer's responsibility stops at **provision + run-existing-tests + write-re
 
 ---
 
-## Sandbox Model (replicated from the PoC)
+## Sandbox Model (adapted from the PoC)
 
-Because Claude runs autonomous loops *inside the cht-agent container*, the container is hardened with the PoC's five independent layers (any one sufficient; all active):
+Because Claude runs autonomous loops *inside the cht-agent container*, the container is hardened so it can **read** public repos but **never push or reach the host**. cht-core and the cht-agent repos are public, so clone/fetch (read) is allowed; write access to any remote is hard-blocked, and **only the host user pushes**. Five independent layers (any one sufficient; all active):
 
-1. **No credentials mounted** — no SSH keys, no `~/.gitconfig`, no `GH_TOKEN`, no host Docker socket *unless* explicitly opted in for lifecycle management.
-2. **System-level git config** (baked in the image) — `pushInsteadOf` rewrites all GitHub URLs to `error://`, requires root to change.
-3. **Hardened, read-only `.git/config`** — remotes → `/dev/null`, mounted `:ro`.
-4. **Pre-push hook + dummy identity** — installed on container start.
-5. **Agent instructions** (`CLAUDE.md`) — explicit "local git only, no remote, no external network except CHT services on the shared net."
+1. **No write credentials, no Docker socket.** No SSH keys, no `~/.gitconfig`, no `GH_TOKEN`, and **no host Docker socket** — a mounted socket grants host-root (launch any image, bind-mount `/`), so it is rejected. The agent never runs Docker; env bring-up is human-gated.
+2. **Push hard-blocked at system git config** (baked in the image) — `pushInsteadOf` rewrites GitHub *push* URLs to `error://` and `push.default=nothing`; requires root to change. **Fetch/clone stay allowed** for public repos.
+3. **No way to authenticate a push** — even past layer 2, there are no tokens/keys in the container, so no remote write can succeed.
+4. **Pre-push hook + dummy identity** — installed on container start as defense in depth.
+5. **Agent instructions** (`CLAUDE.md`) — "reading remotes is fine; never `git push` or change a remote; the host user owns pushing; no external network except CHT services on `cht-agent-net`."
 
-`.claude/settings.json` additionally allow/deny-lists tools (allow: npm, local git, curl, cht-conf, docker compose *if socket mounted*; deny: `git push/fetch/pull/remote`, `ssh`, `rm -rf`). The PoC's **ralph loop** (command-on-repeat with a hard timeout, because Claude stalls indefinitely on rate limits) and **file-based signals** (`stop`/`pause`/`build-request`) are reused for autonomous operation.
+`.claude/settings.json` allow/deny-lists tools — allow: `npm`, read-only/local `git` (`clone`/`fetch`/`pull`/branch/commit), `curl`, `cht-conf`; deny: `git push`, `git remote set-url`, `ssh`, `rm -rf`, and Docker. The PoC's **ralph loop** (command-on-repeat with a hard timeout, because Claude stalls indefinitely on rate limits) and **file-based signals** (`stop`/`pause`/`build-request`) are reused for autonomous operation.
 
 ---
 
@@ -325,7 +382,7 @@ Our design matches this: the Test Environment Layer is the service; the QA Super
 
 ## Notes
 
-1. **Who runs `docker compose`?** Host operator (human-gated, PoC model) vs cht-agent via mounted host Docker socket (sibling containers). Recommendation: human-gated first, socket-mount as opt-in. Decide in Phase 1.
+1. **Who runs `docker`? — RESOLVED: human-gated.** The agent never runs Docker. A mounted host Docker socket grants host-root (launch any image, bind-mount `/`), so it is **rejected on security grounds**. The human brings the env up/down (`local-images`, `compose up/down`); the agent requests bring-up and polls `/api/v2/monitoring`. CouchDB-tier reset is the one exception — done by the agent over the CouchDB HTTP API, no Docker.
 2. **Model B feasibility (deferred).** Whether cht-core's `run-watch` survives containerization with mounted `node_modules` + shared CouchDB. Its own spike, only after Model A works.
 3. **Resource constraints.** `local-images` builds need ~8GB RAM / 50GB disk / 4 cores. Behaviour when unavailable?
 4. **Image caching.** Cache baked images per git SHA to skip webapp rebuilds when unchanged.

--- a/designs/layer_recommendations/test-environment-layer.md
+++ b/designs/layer_recommendations/test-environment-layer.md
@@ -1,37 +1,86 @@
 # Test Environment Layer — Recommendation Document
 
-**Issue:** [medic/cht-agent#16](https://github.com/medic/cht-agent/issues/16)
-**Status:** Draft
-**Date:** 2026-04-13
+**Issues:** [#16](https://github.com/medic/cht-agent/issues/16) (discovery), [#66](https://github.com/medic/cht-agent/issues/66) (implementation), [#43](https://github.com/medic/cht-agent/issues/43) (mock tests)
 
 ---
 
 ## Summary
 
-The Test Environment Layer is responsible for providing the QA Supervisor with a ready, configured, data-populated CHT environment. It is not responsible for test execution, verification, or reporting. Those belong to the QA Supervisor's Test Orchestration Layer ([#18](https://github.com/medic/cht-agent/issues/18)).
+The Test Environment Layer provides the cht-agent with a **live, configured, data-populated CHT instance that it can manipulate and test against**. It is deterministic orchestration — no LLM lives in this layer.
 
-The layer's contract: **"I give you a healthy CHT environment with the right config and test data. You tell me when to reset or tear it down."**
+The decisive architectural fact: **the cht-agent runs inside a container.** The Test Environment Layer does not spin CHT up *inside* the agent (no docker-in-docker). Instead it brings CHT services up on the **same Docker network** as the cht-agent container, sharing the **same cht-core code volume**. The agent then reaches into that shared, networked, volume-mounted environment to apply generated code, seed data, and run tests in place.
 
-### Architectural Placement
+> **The contract:** *"I give you a healthy CHT instance on your network, wired to the same code volume you're editing, with the right config and test data. Code you write into the volume reaches the running env on a (human-gated) rebuild. You tell me when to reset, rebuild, or tear down."*
 
-The Test Environment Layer sits under the **QA Supervisor**, alongside Test Orchestration. It acts as the first step in the QA workflow: before tests can run or manual verification can happen, there must be a live CHT instance.
+The "walk into a secure room and bounce off the walls until tests pass" behaviour is **the containerized cht-agent itself** (its QA Supervisor) acting against this environment — it is *not* a new LLM agent introduced by this layer. This layer builds the room and hands over the keys; the agent does the bouncing.
+
+### Decisions captured (from design review, 2026-06-05)
+
+| Decision | Choice | Consequence |
+|----------|--------|-------------|
+| **Layer identity** | Deterministic provisioning service consumed by the *already-containerized* cht-agent | No LLM in this layer. Iteration intelligence lives in the QA Supervisor, which runs in the cht-agent container. |
+| **Code iteration model** | **Model A — rebuild-on-change** | Agent edits the working copy → human-gated `local-images` rebuild → restart. cht-core has **no in-container hot-reload** today, so the live-mount "Model B" is deferred. No spike for this build. |
+| **PR-review mode** | **Design now, build later** | Interfaces and flow are specified here; implementation lands after the internal-pipeline path. |
+| **Sandbox** | **Replicate the PoC's 5-layer git/credential sandbox**, around the cht-agent container | Claude can run autonomous loops in the room with no remote/credential access. |
+
+---
+
+## Architectural Placement
+
+The layer sits under the **QA Supervisor**, as the first step of QA work:
 
 ```
-QA Supervisor
-├── Test Environment Layer     ← set up environment, config, test data
-└── Test Orchestration Layer   ← run tests, manual QA, verification
+QA Supervisor  (runs inside the cht-agent container)
+├── Test Environment Layer     ← THIS: build/start/seed/health, wire network + volume
+└── Test Orchestration Layer    ← run tests, manual QA, verification, pass/fail (#18)
 ```
 
-### Scope Boundaries
+The Development Supervisor's **Test Generation Layer** *writes* test code. This layer writes *no code* — it provisions the infrastructure those tests run on.
 
-| In Scope | Out of Scope |
-|----------|-------------|
-| Build Docker images from local code | Running tests (Test Orchestration) |
-| Start/stop/reset containers | Browser automation (Test Orchestration) |
-| Health check and readiness polling | Pass/fail judgment (QA Supervisor) |
-| Config discovery from running instance | Reporting and evidence collection (QA Supervisor) |
-| Test data generation and seeding | Test execution strategy (Test Orchestration) |
-| CLI interface for independent invocation | Code validation/linting (Code Validation Layer) |
+### The container topology
+
+```
+                         shared docker network: cht-agent-net
+   ┌───────────────────────────────────────────────────────────────────────┐
+   │                                                                         │
+   │   ┌────────────────────────┐         ┌──────────────────────────────┐  │
+   │   │   cht-agent container   │         │      CHT test environment     │  │
+   │   │  (LangGraph, Claude,    │         │  (brought up by this layer)  │  │
+   │   │   QA Supervisor)        │         │                              │  │
+   │   │                         │  HTTP   │  ┌────────┐  ┌────────────┐  │  │
+   │   │  • edits cht-core code  │ ──────▶ │  │ nginx  │  │  haproxy   │  │  │
+   │   │  • runs cht-conf        │ /api/.. │  └────────┘  └─────┬──────┘  │  │
+   │   │  • runs npm test        │ ◀────── │  ┌────────┐  ┌─────▼──────┐  │  │
+   │   │  • 5-layer git sandbox  │         │  │  api   │  │  sentinel  │  │  │
+   │   │                         │         │  └───┬────┘  └─────┬──────┘  │  │
+   │   └───────────┬─────────────┘         │      └──── couchdb ┘         │  │
+   │               │                       └──────────────┬───────────────┘  │
+   │               │   shared volume: cht-core working copy (rw)              │
+   │               └──────────────────────────────────────┘                  │
+   │   (Model A: agent edits the working copy; a rebuild via local-images     │
+   │    bakes new images that the CHT env runs — no live source mount)        │
+   └───────────────────────────────────────────────────────────────────────┘
+                                      ▲
+                          host operator (control plane):
+                  image builds (local-images), phase approvals,
+                       git remotes, merges  — never DinD
+```
+
+**Why this shape:**
+- **No docker-in-docker.** The cht-agent does not build/run Docker inside itself. Either the host operator brings services up (PoC model, human-gated) or the cht-agent uses a **mounted host Docker socket** to manage *sibling* containers. Both keep us out of DinD. The recommendation is to start with the human-gated host model and treat the socket-mount as an opt-in convenience (see [Open Questions](#open-questions)).
+- **Shared network** means the agent reaches CHT at a stable hostname (e.g. `https://nginx` / `https://haproxy`) with no port juggling.
+- **Shared code volume** (host ↔ cht-agent container) is the working copy the agent edits and the host builds from. Under **Model A** (chosen), code changes reach the running CHT env via a rebuild (`local-images`), *not* a live mount into api/sentinel. Live-mount hot-reload (Model B) is a deferred optimization — see [Code-iteration model](#code-iteration-model-the-re-test-problem).
+
+### The compose artifacts live in the target repo, not in cht-agent
+
+This layer **orchestrates the target repo's own launch tooling** rather than shipping its own compose stack (consistent with "Tool Orchestration Over Reinvention"). cht-core already provides everything needed:
+
+| Target-repo asset | Role in this layer |
+|-------------------|--------------------|
+| [`scripts/docker-helper/cht-docker-compose.sh`](https://github.com/medic/cht-core/blob/master/scripts/docker-helper/cht-docker-compose.sh) | **Published-version bring-up.** Downloads `cht-core.yml` / `cht-couchdb.yml` / `upgrade-service.yml`, generates a `.env` (sets `medic/password`, `CHT_NETWORK`, auto-incremented ports), and offers `start` / `stop` / `destroy`. Used for the PR-review path and any "known good version" environment. |
+| `npm run local-images` + generated `local-build/` compose | **Local-code bring-up.** Builds branch-tagged images from the working copy so the agent tests *its own* changes. Used for the internal pipeline. |
+
+cht-agent contributes only a **thin compose override** that joins the running stack to `cht-agent-net` so the agent container can reach the services. The override layers on top of the target repo's compose files via `docker compose -f <target> -f <override>`. The `CHT_NETWORK` variable the helper already exposes is the seam we attach to. (A future Model B override would additionally mount source into api/sentinel for hot-reload.)
 
 ---
 
@@ -39,302 +88,233 @@ QA Supervisor
 
 ### 1. Environment Lifecycle
 
-Manage the full lifecycle of a local CHT instance built from source.
-
-#### Bootstrap Sequence
+#### Bootstrap sequence
 
 ```
-1. Build images     →  npm run local-images (in cht-core directory)
-2. Start containers →  docker compose -f cht-couchdb.yml -f cht-core.yml up -d
-3. Wait for ready   →  Poll /api/v2/monitoring until healthy
-4. Upload config    →  cht-conf --url=<url> compile-app-settings upload-app-settings
-5. Prepare data     →  Seed contacts, reports, users (see Responsibility #3)
-6. Signal ready     →  Return environment handle to QA Supervisor
+1. Choose bring-up path →  local code  → npm run local-images           (host / human-gated)
+                           published    → scripts/docker-helper/cht-docker-compose.sh
+2. Start services       →  docker compose -f <target compose> -f <cht-agent override> up -d
+                           (override joins cht-agent-net so the agent can reach the services)
+3. Wait for readiness    →  poll /api/v2/monitoring         (exponential backoff)
+4. Upload config        →  cht-conf compile/upload-app-settings
+5. Seed test data       →  see Responsibility #3
+6. Signal ready         →  write environment handle to a file (URL, auth, network, config)
 ```
 
-#### `npm run local-images`
+#### Code-iteration model (the re-test problem)
 
-The primary mechanism for building Docker images from local source code. Produces branch-specific image tags and generates compose files in `local-build/`. This is the correct foundation because it tests the actual code changes in a production-like environment.
+**cht-core ships no in-container hot-reload.** The official `api` image (`node:22-alpine`, `NODE_ENV=production`, entrypoint `docker-entrypoint.sh main`) runs **pre-built artifacts** copied in at build time; it does not watch source. `cht-docker-compose.sh` runs *published* images (no local source mounted at all). `npm run local-images` produces *baked* images. **None of the three reflect a live source edit out of the box** — changing api/sentinel code otherwise requires a rebuild.
 
-```bash
-# In cht-core directory
-npm run local-images
+cht-core's reload story exists only as a **host-side dev workflow**: `npm run dev-api` / `npm run dev-sentinel` run `api run-watch` / `sentinel run-watch` (nodemon-style) as Node processes on the host, pointed at a CouchDB that may be in Docker.
 
-# Start the environment
-cd local-build
-COUCHDB_PASSWORD=password docker compose -f cht-couchdb.yml -f cht-core.yml up -d
+### Model A — rebuild-on-change (CHOSEN for this build)
+
+The agent edits the working copy, then triggers `npm run local-images` + restart, with the heavy build behind a **human-gated phase**. Every code change to any service goes through a rebuild. Guaranteed to work, no custom plumbing, ~3–5 min/iteration. This is the PoC model.
+
+```
+edit code (any service)  →  signal build-request  →  [HUMAN GATE]  →
+  npm run local-images (host)  →  docker compose up -d (restart)  →  re-run tests
 ```
 
-#### Readiness Strategy
+The reset tiers below make this tolerable: most iteration is *config/data* changes (no rebuild), and only *code* changes pay the rebuild cost.
 
-CHT requires multiple services to initialize (HAProxy, API, CouchDB, Sentinel). The layer must confirm the environment is usable before signaling ready.
+### Model B — containerized `run-watch` (DEFERRED optimization)
 
-**Primary approach:** Poll `GET /api/v2/monitoring` with exponential backoff until a successful response. This is the same approach used by cht-conf's e2e test utilities ([cht-docker-utils.js](https://github.com/medic/cht-conf/blob/main/test/e2e/cht-docker-utils.js)).
+cht-core has no in-container hot-reload, but its host-side `run-watch` workflow could be containerized: run `api run-watch` / `sentinel run-watch` in a sidecar container with the working copy + `node_modules` mounted, on the shared network, pointed at the containerized CouchDB (i.e. `dev-api`/`dev-sentinel`, containerized). That would give second-scale backend reloads. It is **not part of this build** — it carries unproven plumbing risk (mounted `node_modules`, watcher-in-container, shared CouchDB) and would need a dedicated spike first. Revisit once Model A is working end-to-end.
+
+#### Readiness strategy
+
+Poll `GET /api/v2/monitoring` with exponential backoff until healthy (the pattern used by cht-conf's e2e utilities, [`cht-docker-utils.js`](https://github.com/medic/cht-conf/blob/main/test/e2e/cht-docker-utils.js)). This mirrors the PoC's `health-check.sh --wait` (60 retries × 5s).
 
 ```typescript
-// Pseudocode
 const waitForReady = async (url: string, maxWaitMs = 120_000): Promise<void> => {
   const start = Date.now();
   let delay = 2_000;
-
   while (Date.now() - start < maxWaitMs) {
-    try {
-      const res = await fetch(`${url}/api/v2/monitoring`);
-      if (res.ok) return;
-    } catch {
-      // not ready yet
-    }
+    try { if ((await fetch(`${url}/api/v2/monitoring`)).ok) return; } catch { /* not up */ }
     await sleep(delay);
     delay = Math.min(delay * 1.5, 15_000);
   }
-
   throw new Error(`CHT did not become ready within ${maxWaitMs}ms`);
 };
 ```
 
-**Supplementary checks:**
-- `docker ps` to confirm all expected containers are running (nginx, sentinel, api, haproxy, healthcheck, couchdb)
-- `GET /api/v1/settings` to confirm the API is serving config (not just accepting connections)
+Supplementary: `docker ps` confirms all expected containers are up; `GET /api/v1/settings` confirms the API is *serving config*, not merely accepting TCP.
 
-#### Reset Mechanism
+#### Phase gates (ported from the PoC)
 
-Between test runs, the environment needs to return to a known state. Three strategies, in order of preference:
+Resource-heavy or human-only steps (image builds, webapp rebuilds, first bring-up) are guarded by a `phase-gate.sh`-style mechanism: `check` / `wait` / `approve` / `status` backed by a `.current-phase` file. The agent **block-waits** on a gate it needs; the human **approves** after verifying. This is exactly how the PoC prevented agents from racing ahead of services that didn't exist yet.
 
-| Strategy | Speed | Isolation | When to Use |
-|----------|-------|-----------|-------------|
-| **CouchDB wipe + reseed** | Fast (~10s) | Good | Between test cases within a session |
-| **Container restart** | Medium (~30-60s) | Better | Between test suites or after config changes |
-| **Full teardown + rebuild** | Slow (~3-5min) | Complete | Between tickets or after code changes |
+#### Reset mechanism (three tiers)
 
-The default should be **container restart** as a balance of speed and isolation. Full teardown is reserved for when the code under test has changed (new images needed).
+| Strategy | Speed | Isolation | When |
+|----------|-------|-----------|------|
+| CouchDB wipe + reseed | ~10s | Good | Between test cases in a session; after config/data changes |
+| Container restart | ~30–60s | Better | Between suites / after config change |
+| Full teardown + rebuild | ~3–5min | Complete | Between tickets / **after any code change** (Model A) |
 
-```bash
-# Quick reset: restart containers, reseed data
-docker compose restart
-# wait for readiness again
-# reseed test data
-
-# Full teardown
-docker compose down -v
-# rebuild if needed
-docker compose up -d
-```
+Default: **CouchDB wipe + reseed** for config/data iterations. Under Model A, **any code change to api/sentinel/webapp requires the full rebuild tier** (human-gated). This is the cost Model B would later remove for backend code.
 
 #### Teardown
 
-```bash
-docker compose -f cht-couchdb.yml -f cht-core.yml down -v
-```
-
-The `-v` flag removes volumes to ensure clean state. The layer should always teardown on completion or failure to avoid orphaned containers.
+`docker compose down -v` (the `-v` clears volumes for a clean slate). Always run on completion or failure to avoid orphaned containers.
 
 ### 2. Config Discovery
 
-Connect to a running CHT instance and discover its deployed configuration. This enables the layer to generate test data that is valid for the specific deployment.
+Connect to the running instance and learn its deployed configuration so generated test data is *valid for this deployment*.
 
-#### Data Sources
-
-| Endpoint | Data Retrieved |
-|----------|---------------|
+| Endpoint | Data |
+|----------|------|
 | `GET /api/v1/settings` | `contact_types` (hierarchy), `roles`, `permissions`, `transitions`, task/target config |
-| `GET /api/v1/forms` | List of installed forms (returns array of filenames) |
-| `GET /api/v1/forms/{id}.xml` | Individual form definitions |
-| CouchDB `_all_docs` | Existing documents for reference |
+| `GET /api/v1/forms` | installed form list |
+| `GET /api/v1/forms/{id}.xml` | individual form definitions |
+| CouchDB `_all_docs` | existing documents for reference |
 
-#### Discovery Flow
-
-```typescript
-// Pseudocode
-const discoverConfig = async (url: string, auth: string) => {
-  const settings = await fetch(`${url}/api/v1/settings`, { headers: { Authorization: auth } });
-  const forms = await fetch(`${url}/api/v1/forms`, { headers: { Authorization: auth } });
-
-  return {
-    contactTypes: settings.contact_types,   // hierarchy structure
-    roles: settings.roles,                   // user types (online/offline)
-    permissions: settings.permissions,       // role-permission mapping
-    transitions: settings.transitions,       // enabled server-side transitions
-    forms: forms,                            // installed form list
-  };
-};
-```
-
-#### Why Config-Driven?
-
-The QA layer must work with **any** CHT deployment, not just a hardcoded assumed structure. Different deployments have different hierarchies, roles, and forms. Generating test data that doesn't match the deployed config will produce false failures.
+Config-driven generation is what lets the layer work against *any* deployment instead of a hardcoded hierarchy — mismatched data produces false test failures.
 
 ### 3. Test Data Preparation
 
-Generate and upload test data that conforms to the discovered configuration.
-
-#### Tools
+Generate and upload data that conforms to the discovered config.
 
 | Tool | Purpose | Invocation |
 |------|---------|------------|
-| **cht-conf** `csv-to-docs` | Convert CSV → JSON documents | `cht csv-to-docs` then `cht upload-docs` |
-| **cht-conf** `create-users` | Create user accounts from CSV | `cht create-users` (reads `users.csv`) |
-| **cht-conf** `compile-app-settings` | Compile and upload app config | `cht compile-app-settings upload-app-settings` |
-| **CHT API** | Direct document creation | `POST /api/v1/people`, `POST /api/v1/places` |
-| **CouchDB API** | Bulk document operations | `POST /medic/_bulk_docs` |
-| **cht-datasource** | Typed data access (read/verify) | `@medic/cht-datasource` remote adapter |
+| `cht-conf` `csv-to-docs` + `upload-docs` | CSV → JSON docs → instance | child_process |
+| `cht-conf` `create-users` | user accounts from CSV | child_process |
+| `cht-conf` `compile-app-settings` `upload-app-settings` | compile + upload config | child_process |
+| CHT API | direct doc creation | `POST /api/v1/people`, `/places` |
+| CouchDB API | bulk ops | `POST /medic/_bulk_docs` |
+| `cht-datasource` | typed read/verify (remote adapter, CHT 4.18.0+) | `@medic/cht-datasource` |
+| `cht-conf-test-harness` | config-level tests (tasks/targets/contact-summary/forms) **without** a full instance | in-process |
 
-#### Programmatic cht-conf Invocation
+**Data strategy:** read config → build a valid hierarchy (places per level, people assigned) → create users with valid roles → generate reports matching installed forms → upload. Keep it **minimal but complete**.
 
-Based on the existing pattern in [cht-core's test utilities](https://github.com/medic/cht-core/blob/master/tests/utils/cht-conf.js):
-
-```typescript
-const { exec } = require('child_process');
-const { promisify } = require('util');
-const execAsync = promisify(exec);
-
-const runChtConf = async (action: string, cwd: string, url: string) => {
-  const chtConfPath = path.resolve(process.cwd(), './node_modules/.bin/cht');
-  const { stdout } = await execAsync(
-    `${chtConfPath} --url=${url} ${action} --force --accept-self-signed-certs --debug`,
-    { cwd }
-  );
-  return stdout;
-};
-```
-
-#### Data Generation Strategy
-
-1. Read discovered config (`contact_types`, `roles`, `forms`)
-2. Generate a valid hierarchy (places at each level, people assigned to places)
-3. Create users with appropriate roles
-4. Generate reports that match installed form definitions
-5. Upload via cht-conf or CHT API
-
-The data must be **minimal but complete**: enough to exercise the feature under test without unnecessary volume.
-
-#### cht-conf-test-harness
-
-For testing CHT app configurations (tasks, targets, contact summaries, forms) **without a full CHT instance**, [`cht-conf-test-harness`](https://github.com/medic/cht-conf-test-harness) provides a lightweight alternative:
-
-```javascript
-const Harness = require('cht-conf-test-harness');
-const harness = new Harness();
-
-await harness.start();
-await harness.setNow('2026-01-15');
-const tasks = await harness.getTasks();
-await harness.stop();
-```
-
-This is useful when the Test Generation agent produces config-level tests (task logic, target calculations) that don't require a full environment. The Test Environment Layer should detect when `cht-conf-test-harness` is sufficient and skip full environment setup.
+**Harness shortcut:** when the Test Generation agent produced only config-level tests (task logic, target math, contact summaries), `cht-conf-test-harness` runs them with no Docker at all. The layer should detect this and skip full bring-up.
 
 ---
 
 ## Tool Capabilities Matrix
 
-| Tool | Environment Lifecycle | Config Discovery | Test Data Prep | Notes |
-|------|----------------------|-----------------|----------------|-------|
-| `npm run local-images` | Build images from local code | - | - | Foundation for testing code changes |
-| `docker compose` | Start/stop/reset containers | - | - | Lifecycle management |
-| CHT API (`/api/v1/*`) | Health check (`/v2/monitoring`) | Settings, forms | Create contacts, reports | Primary programmatic interface |
-| `cht-conf` | - | - | Upload config, create users, seed docs | CLI tool, invoke via child_process |
-| `cht-conf-test-harness` | Simulates CHT (no Docker) | - | Embedded test data | Config-level tests only (tasks, targets, forms) |
-| `cht-toolbox` | - | - | Replicate docs between instances | Copy contacts/hierarchies from existing environments ([repo](https://github.com/jkuester/chtoolbox)) |
-| `cht-datasource` | - | - | Read/verify data (remote adapter) | Typed API for data access (CHT 4.18.0+) |
-| CouchDB API | - | - | Bulk doc operations | Direct database access for seeding/cleanup |
+| Tool | Lifecycle | Config Discovery | Data Prep | Notes |
+|------|:--------:|:---------------:|:---------:|-------|
+| `npm run local-images` | build baked images | — | — | webapp/nginx; human-gated |
+| `docker compose` | start/stop/reset, network + volume wiring | — | — | sibling containers, not DinD |
+| CHT API `/api/v1/*`, `/api/v2/monitoring` | health/readiness | settings, forms | create contacts/reports | primary programmatic interface |
+| `cht-conf` | — | — | upload config, users, docs | child_process |
+| `cht-conf-test-harness` | simulates CHT (no Docker) | — | embedded data | config-level tests only |
+| `cht-toolbox` | — | — | replicate docs between instances | seed from a real env ([chtoolbox](https://github.com/jkuester/chtoolbox)) |
+| `cht-datasource` | — | — | read/verify | typed API, 4.18.0+ |
+| CouchDB API | — | — | bulk seed/cleanup | direct DB access |
 
 ---
 
-## CLI Interface
+## Interfaces
 
-The layer should be independently callable via `npm run test-env`, following the same pattern as `npm run research <ticket>` for the Research Supervisor. This enables:
-- Manual QA workflows from Claude Code containers
-- Overnight refactor testing where Claude can trigger environment setup independently
-- Standalone environment management without running the full cht-agent pipeline
+### CLI (independent invocation)
 
-### Usage
+Follows the `npm run research <ticket>` pattern so the layer is callable standalone — for manual QA, overnight refactors, and (later) PR review.
 
 ```bash
-# Full setup: build from local code, start, discover config, seed data
-npm run test-env -- --cht-core-path /path/to/cht-core
+# Full setup against a code volume the agent shares:
+npm run test-env -- --cht-core-path /workspace/cht-core
 
-# Use a specific CHT version from Docker Hub instead of building from source
+# Use a published image instead of building from source:
 npm run test-env -- --version 4.18.0
 
-# Teardown a running environment
-npm run test-env -- --teardown
+# Lifecycle:
+npm run test-env -- --reset      # restart + reseed
+npm run test-env -- --teardown   # down -v
 
-# Reset to clean state (restart containers, reseed data)
-npm run test-env -- --reset
+# PR review (designed now, built later):
+npm run test-env -- --pr <branch|url>   # checkout, provision, run existing suite, write report
 ```
 
-The primary command (`npm run test-env -- --cht-core-path ...`) runs the full bootstrap sequence: build images, start containers, wait for readiness, discover config, seed test data, and print the environment URL and credentials. This is the equivalent of `npm run research <ticket>` but for environment setup.
+The handle (URL, auth, network name, discovered config) is written to a file (e.g. `.test-env/handle.json`) so the QA Supervisor — or a later inference step — can read it. This is the "**outputs written to a file, called for inference later**" 
 
-### LangGraph Node Interface
-
-When called as part of the cht-agent pipeline, the layer exposes the same capabilities through a LangGraph node:
+### LangGraph node
 
 ```typescript
 interface TestEnvironmentState {
-  chtCorePath?: string;        // path to cht-core with code changes
-  version?: string;            // CHT version to use (if not building from source)
-  environmentUrl?: string;     // URL of running instance (output)
-  environmentAuth?: string;    // auth credentials (output)
-  config?: DiscoveredConfig;   // discovered configuration (output)
-  status: 'idle' | 'starting' | 'ready' | 'error' | 'teardown';
+  chtCorePath?: string;       // shared code volume path
+  version?: string;           // published image instead of source build
+  network?: string;           // docker network to join (defaults to cht-agent's)
+  environmentUrl?: string;    // output: e.g. https://nginx
+  environmentAuth?: string;   // output
+  config?: DiscoveredConfig;  // output: contact_types, roles, forms, transitions
+  handlePath?: string;        // output: path to the written handle file
+  status: 'idle' | 'building' | 'starting' | 'seeding' | 'ready' | 'error' | 'teardown';
   error?: string;
 }
 ```
+
+These types belong in `src/types/index.ts` alongside the existing `ResearchState`.
+
+---
+
+## PR-Review Mode (designed now, built later)
+
+The independent first-pass reviewer @Hareet described: *"if we believe the user did not run tests, or an inference pass would help, launch this part of the cht-agent."*
+
+**Flow (to implement after the internal-pipeline path):**
+1. `--pr <branch|url>` → checkout the PR branch into the shared code volume (read-only sandbox; the agent cannot push — see Sandbox).
+2. Provision the environment against that code (Model A rebuild applies).
+3. Run the **existing** test suite the PR *should* have run (`npm run unit-*`, integration where infra allows).
+4. Write results + diff context to the handle file.
+5. *(optional, flagged)* Hand the results to an inference step in the QA Supervisor for a first-pass review comment.
+
+This layer's responsibility stops at **provision + run-existing-tests + write-report**. The inference/review judgement is the QA Supervisor's, consistent with the scope boundary.
+
+---
+
+## Sandbox Model (replicated from the PoC)
+
+Because Claude runs autonomous loops *inside the cht-agent container*, the container is hardened with the PoC's five independent layers (any one sufficient; all active):
+
+1. **No credentials mounted** — no SSH keys, no `~/.gitconfig`, no `GH_TOKEN`, no host Docker socket *unless* explicitly opted in for lifecycle management.
+2. **System-level git config** (baked in the image) — `pushInsteadOf` rewrites all GitHub URLs to `error://`, requires root to change.
+3. **Hardened, read-only `.git/config`** — remotes → `/dev/null`, mounted `:ro`.
+4. **Pre-push hook + dummy identity** — installed on container start.
+5. **Agent instructions** (`CLAUDE.md`) — explicit "local git only, no remote, no external network except CHT services on the shared net."
+
+`.claude/settings.json` additionally allow/deny-lists tools (allow: npm, local git, curl, cht-conf, docker compose *if socket mounted*; deny: `git push/fetch/pull/remote`, `ssh`, `rm -rf`). The PoC's **ralph loop** (command-on-repeat with a hard timeout, because Claude stalls indefinitely on rate limits) and **file-based signals** (`stop`/`pause`/`build-request`) are reused for autonomous operation.
 
 ---
 
 ## Industry Context
 
-Research into how other multi-agent software development systems handle test environments reveals a clear pattern: **production systems universally separate environment setup from agent logic**.
+Production multi-agent dev systems universally separate environment setup from agent logic — environment is a *service the agent consumes*, not a step it performs:
 
 | System | Approach |
 |--------|----------|
-| SWE-Agent | SWE-ReX runtime abstraction (shared service, Docker-based) |
-| Devin | Pre-configured Devbox sandbox (infrastructure layer) |
-| OpenHands | Workspace SDK package (modular, pluggable backends) |
-| Amazon Q | Devfile declarations (configuration-as-code) |
-| MetaGPT, ChatDev | Implicit (not modeled, assumed to exist) |
+| SWE-Agent | SWE-ReX runtime abstraction (shared, Docker-based) |
+| Devin | pre-configured Devbox sandbox |
+| OpenHands | Workspace SDK (pluggable backends) |
+| Amazon Q | Devfile declarations |
+| MetaGPT / ChatDev | implicit (assumed to exist) |
 
-The common pattern is that environment management is a **service** that testing agents consume, not a step that a testing agent performs itself. Our design follows the same principle: the Test Environment Layer provides the service, the Test Orchestration Layer consumes it.
-
----
-
-## Integration with QA Supervisor Workflow
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                     QA Supervisor                        │
-│                                                         │
-│  1. Test Environment Layer                              │
-│     ├── Build images (npm run local-images)             │
-│     ├── Start containers (docker compose up)            │
-│     ├── Wait for readiness (/api/v2/monitoring)         │
-│     ├── Discover config (/api/v1/settings, /forms)      │
-│     ├── Seed test data (cht-conf, CHT API)              │
-│     └── Signal ready → environment handle               │
-│                          │                              │
-│  2. Test Orchestration Layer                            │
-│     ├── Run unit tests (npm test)                       │
-│     ├── Run integration tests (against live CHT)        │
-│     ├── Run e2e tests (WebdriverIO)                     │
-│     ├── Manual QA verification                          │
-│     └── Coverage analysis (nyc)                         │
-│                          │                              │
-│  3. Signal complete → reset or teardown                 │
-│                                                         │
-└─────────────────────────────────────────────────────────┘
-```
+Our design matches this: the Test Environment Layer is the service; the QA Supervisor is the consumer.
 
 ---
 
-## Open Questions
+## Implementation Plan (the step-by-step for #66 + #43)
 
-1. **Docker-in-Docker:** If cht-agent runs inside a container (e.g., Claude Code container), can it reliably run `docker compose`? May need Docker socket mounting or sibling container patterns.
+> Detailed in the working plan; summarized here so the doc is self-contained.
 
-2. **Resource constraints:** `npm run local-images` builds multiple Docker images. Minimum specs per CHT docs: 8GB RAM, 50GB disk, 4 cores. How do we handle environments where this isn't available?
+- **Phase 0 — Scaffolding & types.** Add `TestEnvironmentState`, `DiscoveredConfig`, environment-handle types to `src/types/index.ts`. Stub `src/agents/test-environment-agent.ts` with a **mock mode** mirroring the other agents (this is what #43 tests). Add `test-env` npm script + `src/cli/test-env.ts`.
+- **Phase 1 — Lifecycle (Model A).** Orchestrate the target repo's bring-up (`local-images` for local code, `cht-docker-compose.sh` for published versions) + thin compose override to join `cht-agent-net`. Readiness polling (`/api/v2/monitoring`), phase gates for the human-gated rebuild, three-tier reset, teardown. **No hot-reload, no spike.**
+- **Phase 2 — Config discovery.** `/api/v1/settings` + `/forms` parsing into `DiscoveredConfig`.
+- **Phase 3 — Test data prep.** cht-conf child_process wrappers, config-driven generation, harness shortcut detection.
+- **Phase 4 — Handle + LangGraph node + CLI.** Write handle file; wire the node into the QA Supervisor graph; finish the standalone CLI.
+- **Phase 5 — Mock tests (#43).** `test/agents/test-environment-agent.spec.ts`: constructor/init, mock-mode structure, config generation, fixture generation, error handling — no real LLM, no real Docker.
+- **Phase 6 (later) — PR-review mode & sandbox container.** `--pr` flow; port the PoC `.devcontainer` security layers.
+- **Deferred — Model B hot-reload.** Containerize cht-core's `run-watch` (needs its own spike). Only after Model A is working end-to-end.
 
-3. **Caching strategy:** Building images from source is slow. Can we cache built images per git SHA and skip rebuilds when the code hasn't changed?
+---
 
-4. **Parallel environments:** Can we run multiple CHT instances (different ports) for parallel test runs? This matters for the Master Supervisor if it processes multiple tickets concurrently.
+## Notes
 
-5. **cht-conf-test-harness scope:** When should the layer use the lightweight harness instead of a full Docker environment? Need heuristics based on what the Test Generation agent produced (config tests vs integration tests vs e2e tests).
+1. **Who runs `docker compose`?** Host operator (human-gated, PoC model) vs cht-agent via mounted host Docker socket (sibling containers). Recommendation: human-gated first, socket-mount as opt-in. Decide in Phase 1.
+2. **Model B feasibility (deferred).** Whether cht-core's `run-watch` survives containerization with mounted `node_modules` + shared CouchDB. Its own spike, only after Model A works.
+3. **Resource constraints.** `local-images` builds need ~8GB RAM / 50GB disk / 4 cores. Behaviour when unavailable?
+4. **Image caching.** Cache baked images per git SHA to skip webapp rebuilds when unchanged.
+5. **Parallel environments.** Multiple instances (distinct networks) for concurrent tickets from the Master Supervisor.
+6. **Harness-vs-Docker heuristic.** How the layer decides `cht-conf-test-harness` is sufficient based on what the Test Generation agent produced.

--- a/designs/layer_recommendations/test-environment-layer.md
+++ b/designs/layer_recommendations/test-environment-layer.md
@@ -37,6 +37,15 @@ QA Supervisor  (runs inside the cht-agent container)
 
 The Development Supervisor's **Test Generation Layer** *writes* test code. This layer writes *no code* — it provisions the infrastructure those tests run on.
 
+> **Precondition — who provides cht-core:** the cht-core working copy (a standing local clone, modified in place by the Development Supervisor's Code Generation Layer in the internal pipeline) is an **input** to this layer. The Test Environment Layer never clones or edits code — it builds, runs, and seeds the copy it's handed. Only standalone/PR-review mode performs a checkout, since no Dev Supervisor ran first.
+>
+> | Mode | Who provides the working copy | This layer's job |
+> |------|------------------------------|------------------|
+> | Internal pipeline | Dev Supervisor (clones + writes generated code in place) | build + run + seed the already-present copy |
+> | Standalone / PR-review | The CLI invocation (`--cht-core-path` points at it, or `--pr` checks a branch out) | checkout *only in PR mode*, then build + run + seed |
+>
+> *Status:* this is design intent. The Development Supervisor is not yet started, and no clone step / `CHT_CORE_PATH` contract exists in code today — the working copy's origin is a shared assumption across the layer recommendations, not a built handoff.
+
 ### The container topology
 
 ```
@@ -300,7 +309,7 @@ Our design matches this: the Test Environment Layer is the service; the QA Super
 > Detailed in the working plan; summarized here so the doc is self-contained.
 
 - **Phase 0 — Scaffolding & types.** Add `TestEnvironmentState`, `DiscoveredConfig`, environment-handle types to `src/types/index.ts`. Stub `src/agents/test-environment-agent.ts` with a **mock mode** mirroring the other agents (this is what #43 tests). Add `test-env` npm script + `src/cli/test-env.ts`.
-- **Phase 1 — Lifecycle (Model A).** Orchestrate the target repo's bring-up (`local-images` for local code, `cht-docker-compose.sh` for published versions) + thin compose override to join `cht-agent-net`. Readiness polling (`/api/v2/monitoring`), phase gates for the human-gated rebuild, three-tier reset, teardown. **No hot-reload, no spike.**
+- **Phase 1 — Lifecycle (Model A).** Build + run + seed the **already-present** cht-core working copy (build via `local-images`; for standalone/published use `cht-docker-compose.sh`) + thin compose override to join `cht-agent-net`. Readiness polling (`/api/v2/monitoring`), phase gates for the human-gated rebuild, three-tier reset, teardown. **No clone, no hot-reload, no spike** — the working copy is an input (see Precondition).
 - **Phase 2 — Config discovery.** `/api/v1/settings` + `/forms` parsing into `DiscoveredConfig`.
 - **Phase 3 — Test data prep.** cht-conf child_process wrappers, config-driven generation, harness shortcut detection.
 - **Phase 4 — Handle + LangGraph node + CLI.** Write handle file; wire the node into the QA Supervisor graph; finish the standalone CLI.


### PR DESCRIPTION
## Summary

- Recommendation document for the Test Environment Layer, addressing the discovery requirements in #16
- Scoped to three responsibilities: environment lifecycle, config discovery, and test data preparation
- Addresses all feedback from @Hareet's [review comment](https://github.com/medic/cht-agent/issues/16#issuecomment-4187414670)

## Details

- Bootstrap sequence: `npm run local-images` → docker compose → readiness polling → config upload → data seeding → signal ready
- Readiness strategy: poll `/api/v2/monitoring` with exponential backoff (same pattern as cht-conf's e2e test utilities)
- Reset mechanism: three-tier strategy (CouchDB wipe, container restart, full teardown) with speed/isolation tradeoffs
- Tool capabilities matrix covering cht-conf, cht-conf-test-harness, cht-toolbox, cht-datasource, CHT API, CouchDB API
- CLI interface (`npm run test-env`) for independent invocation, following the same pattern as `npm run research`
- LangGraph node interface for pipeline integration
- Industry context from SWE-Agent, Devin, OpenHands, Amazon Q, MetaGPT

## Test plan

- [x] Review recommendation document for accuracy
- [x] Verify tool evaluation matches current CHT tooling
- [x] Confirm scope boundaries align with Test Orchestration Layer (#18)
- [x] Validate bootstrap sequence against actual `npm run local-images` workflow

Closes #16