### PR TITLE
fix(ci): prevent script injection in conventional commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,12 +13,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 22.x
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
       - name: Lint title
-        run: npx --no -- commitlint <<< "${{ github.event.pull_request.title }}"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: npx --no -- commitlint <<< "$PR_TITLE"


### PR DESCRIPTION
## Summary
- **Fix SonarCloud security blocker**: PR title was interpolated directly in a `run:` block, enabling shell injection via crafted PR titles. Now passed through an `env:` variable instead.
- **Add `--ignore-scripts`** to `npm ci` to prevent execution of arbitrary post-install scripts.
- **Update actions** (`checkout@v6`, `setup-node@v6`) and Node (`22.x`) to match the rest of the CI.