### PR TITLE
feat(#43): add Test Environment Agent mock mode and tests

### DIFF
--- a/src/agents/test-environment-agent.mock-data.ts
+++ b/src/agents/test-environment-agent.mock-data.ts
@@ -1,0 +1,51 @@
+import { DiscoveredConfig, TestDataResult } from '../types';
+
+/**
+ * Raw deterministic fixtures for the Test Environment Agent's mock mode.
+ *
+ * The agent wraps these and stamps `source` itself (mirrors how
+ * code-context-agent.mock-data holds raw data while the agent computes the
+ * envelope). No Docker, cht-conf, or CouchDB calls are made in mock mode.
+ */
+export type MockTestEnvData = {
+  url: string;
+  auth: { user: string; password: string };
+  network: string;
+  config: DiscoveredConfig;
+  testData: TestDataResult;
+};
+
+export const MOCK_TEST_ENV_DATA: MockTestEnvData = {
+  url: 'https://nginx',
+  // matches the defaults set by cht-core's scripts/docker-helper/cht-docker-compose.sh
+  auth: { user: 'medic', password: 'password' },
+  network: 'cht-agent-net',
+  config: {
+    contactTypes: [
+      { id: 'district_hospital' },
+      { id: 'health_center', parents: ['district_hospital'] },
+      { id: 'clinic', parents: ['health_center'] },
+      { id: 'person', parents: ['clinic', 'health_center'], person: true },
+    ],
+    roles: {
+      chw: { name: 'CHW', offline: true },
+      supervisor: { name: 'Supervisor', offline: false },
+    },
+    permissions: {
+      can_edit: ['chw', 'supervisor'],
+      can_export_messages: ['supervisor'],
+    },
+    transitions: {
+      update_clinics: true,
+      death_reporting: { disable: false },
+    },
+    forms: ['delivery', 'pregnancy', 'assessment'],
+  },
+  testData: {
+    placesCreated: 3,
+    peopleCreated: 5,
+    reportsCreated: 4,
+    usersCreated: 2,
+    warnings: [],
+  },
+};

--- a/src/agents/test-environment-agent.ts
+++ b/src/agents/test-environment-agent.ts
@@ -37,18 +37,18 @@ export class TestEnvironmentAgent {
       throw new Error('provision requires either chtCorePath or version');
     }
 
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
     console.log('\n[Test Environment Agent] Provisioning environment...');
     console.log(
       `[Test Environment Agent] Source: ${options.chtCorePath ? `local code (${options.chtCorePath})` : `published version ${options.version}`}`
     );
 
-    if (!this.useMockDocker) {
-      throw new Error(NOT_IMPLEMENTED);
-    }
-
     const handle: EnvironmentHandle = {
       url: MOCK_TEST_ENV_DATA.url,
-      auth: MOCK_TEST_ENV_DATA.auth,
+      auth: { ...MOCK_TEST_ENV_DATA.auth },
       network: options.network ?? MOCK_TEST_ENV_DATA.network,
       chtCorePath: options.chtCorePath,
       source: 'mock',
@@ -63,12 +63,11 @@ export class TestEnvironmentAgent {
    * instance. Defaults to cht-core's in-repo `config/default` project.
    */
   async applyConfig(handle: EnvironmentHandle, configPath = 'config/default'): Promise<void> {
-    console.log(`[Test Environment Agent] Applying config: ${configPath} -> ${handle.url}`);
-
     if (!this.useMockDocker) {
       throw new Error(NOT_IMPLEMENTED);
     }
 
+    console.log(`[Test Environment Agent] Applying config: ${configPath} -> ${handle.url}`);
     console.log('[Test Environment Agent] (mock) config applied');
   }
 
@@ -77,13 +76,12 @@ export class TestEnvironmentAgent {
    * can be generated to conform to it.
    */
   async discoverConfig(handle: EnvironmentHandle): Promise<DiscoveredConfig> {
-    console.log(`[Test Environment Agent] Discovering config from ${handle.url}...`);
-
     if (!this.useMockDocker) {
       throw new Error(NOT_IMPLEMENTED);
     }
 
-    const config = MOCK_TEST_ENV_DATA.config;
+    console.log(`[Test Environment Agent] Discovering config from ${handle.url}...`);
+    const config = structuredClone(MOCK_TEST_ENV_DATA.config);
     console.log(
       `[Test Environment Agent] Discovered ${config.contactTypes.length} contact types, ` +
         `${Object.keys(config.roles).length} roles, ${config.forms.length} forms`
@@ -99,15 +97,14 @@ export class TestEnvironmentAgent {
     handle: EnvironmentHandle,
     config: DiscoveredConfig
   ): Promise<TestDataResult> {
-    console.log(
-      `[Test Environment Agent] Preparing test data for ${config.contactTypes.length} contact types -> ${handle.url}`
-    );
-
     if (!this.useMockDocker) {
       throw new Error(NOT_IMPLEMENTED);
     }
 
-    const result = MOCK_TEST_ENV_DATA.testData;
+    console.log(
+      `[Test Environment Agent] Preparing test data for ${config.contactTypes.length} contact types -> ${handle.url}`
+    );
+    const result = structuredClone(MOCK_TEST_ENV_DATA.testData);
     console.log(
       `[Test Environment Agent] Seeded ${result.placesCreated} places, ` +
         `${result.peopleCreated} people, ${result.reportsCreated} reports, ` +
@@ -121,12 +118,11 @@ export class TestEnvironmentAgent {
    * in the recommendation doc.
    */
   async reset(handle: EnvironmentHandle, tier: ResetTier): Promise<void> {
-    console.log(`[Test Environment Agent] Reset (${tier}) -> ${handle.url}`);
-
     if (!this.useMockDocker) {
       throw new Error(NOT_IMPLEMENTED);
     }
 
+    console.log(`[Test Environment Agent] Reset (${tier}) -> ${handle.url}`);
     console.log('[Test Environment Agent] (mock) reset complete');
   }
 
@@ -134,12 +130,11 @@ export class TestEnvironmentAgent {
    * Tear the environment down and clean up volumes.
    */
   async teardown(handle: EnvironmentHandle): Promise<void> {
-    console.log(`[Test Environment Agent] Teardown -> ${handle.url}`);
-
     if (!this.useMockDocker) {
       throw new Error(NOT_IMPLEMENTED);
     }
 
+    console.log(`[Test Environment Agent] Teardown -> ${handle.url}`);
     console.log('[Test Environment Agent] (mock) teardown complete');
   }
 }

--- a/src/agents/test-environment-agent.ts
+++ b/src/agents/test-environment-agent.ts
@@ -1,0 +1,145 @@
+/**
+ * Test Environment Agent
+ *
+ * Deterministic provisioning orchestrator for the Test Environment Layer
+ * (QA Supervisor). It provisions a live CHT instance, applies a config,
+ * discovers the deployed config, and seeds conforming test data. No LLM is
+ * involved. This file implements mock mode only; the real Docker / cht-conf /
+ * CouchDB orchestration lands in #66.
+ *
+ * See: designs/layer_recommendations/test-environment-layer.md
+ */
+
+import {
+  DiscoveredConfig,
+  EnvironmentHandle,
+  ProvisionOptions,
+  ResetTier,
+  TestDataResult,
+} from '../types';
+import { MOCK_TEST_ENV_DATA } from './test-environment-agent.mock-data';
+
+const NOT_IMPLEMENTED = 'Docker orchestration not yet implemented';
+
+export class TestEnvironmentAgent {
+  private readonly useMockDocker: boolean;
+
+  constructor(options: { useMockDocker?: boolean } = {}) {
+    this.useMockDocker = options.useMockDocker !== false;
+  }
+
+  /**
+   * Bring up a reachable CHT environment. Requires either a local working copy
+   * (chtCorePath, built via local-images) or a published version.
+   */
+  async provision(options: ProvisionOptions): Promise<EnvironmentHandle> {
+    if (!options.chtCorePath && !options.version) {
+      throw new Error('provision requires either chtCorePath or version');
+    }
+
+    console.log('\n[Test Environment Agent] Provisioning environment...');
+    console.log(
+      `[Test Environment Agent] Source: ${options.chtCorePath ? `local code (${options.chtCorePath})` : `published version ${options.version}`}`
+    );
+
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
+    const handle: EnvironmentHandle = {
+      url: MOCK_TEST_ENV_DATA.url,
+      auth: MOCK_TEST_ENV_DATA.auth,
+      network: options.network ?? MOCK_TEST_ENV_DATA.network,
+      chtCorePath: options.chtCorePath,
+      source: 'mock',
+    };
+
+    console.log(`[Test Environment Agent] Ready at ${handle.url} (network: ${handle.network})`);
+    return handle;
+  }
+
+  /**
+   * Apply (compile + upload) a config project from the working copy to the
+   * instance. Defaults to cht-core's in-repo `config/default` project.
+   */
+  async applyConfig(handle: EnvironmentHandle, configPath = 'config/default'): Promise<void> {
+    console.log(`[Test Environment Agent] Applying config: ${configPath} -> ${handle.url}`);
+
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
+    console.log('[Test Environment Agent] (mock) config applied');
+  }
+
+  /**
+   * Read the deployed configuration back from the running instance so test data
+   * can be generated to conform to it.
+   */
+  async discoverConfig(handle: EnvironmentHandle): Promise<DiscoveredConfig> {
+    console.log(`[Test Environment Agent] Discovering config from ${handle.url}...`);
+
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
+    const config = MOCK_TEST_ENV_DATA.config;
+    console.log(
+      `[Test Environment Agent] Discovered ${config.contactTypes.length} contact types, ` +
+        `${Object.keys(config.roles).length} roles, ${config.forms.length} forms`
+    );
+    return config;
+  }
+
+  /**
+   * Generate and seed test data (places, people, reports, users) that conforms
+   * to the discovered config.
+   */
+  async prepareTestData(
+    handle: EnvironmentHandle,
+    config: DiscoveredConfig
+  ): Promise<TestDataResult> {
+    console.log(
+      `[Test Environment Agent] Preparing test data for ${config.contactTypes.length} contact types -> ${handle.url}`
+    );
+
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
+    const result = MOCK_TEST_ENV_DATA.testData;
+    console.log(
+      `[Test Environment Agent] Seeded ${result.placesCreated} places, ` +
+        `${result.peopleCreated} people, ${result.reportsCreated} reports, ` +
+        `${result.usersCreated} users`
+    );
+    return result;
+  }
+
+  /**
+   * Reset the environment to a known state. See the three-tier reset strategy
+   * in the recommendation doc.
+   */
+  async reset(handle: EnvironmentHandle, tier: ResetTier): Promise<void> {
+    console.log(`[Test Environment Agent] Reset (${tier}) -> ${handle.url}`);
+
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
+    console.log('[Test Environment Agent] (mock) reset complete');
+  }
+
+  /**
+   * Tear the environment down and clean up volumes.
+   */
+  async teardown(handle: EnvironmentHandle): Promise<void> {
+    console.log(`[Test Environment Agent] Teardown -> ${handle.url}`);
+
+    if (!this.useMockDocker) {
+      throw new Error(NOT_IMPLEMENTED);
+    }
+
+    console.log('[Test Environment Agent] (mock) teardown complete');
+  }
+}

--- a/src/agents/test-environment-agent.ts
+++ b/src/agents/test-environment-agent.ts
@@ -41,10 +41,12 @@ export class TestEnvironmentAgent {
       throw new Error(NOT_IMPLEMENTED);
     }
 
+    const source = options.chtCorePath
+      ? `local code (${options.chtCorePath})`
+      : `published version ${options.version}`;
+
     console.log('\n[Test Environment Agent] Provisioning environment...');
-    console.log(
-      `[Test Environment Agent] Source: ${options.chtCorePath ? `local code (${options.chtCorePath})` : `published version ${options.version}`}`
-    );
+    console.log(`[Test Environment Agent] Source: ${source}`);
 
     const handle: EnvironmentHandle = {
       url: MOCK_TEST_ENV_DATA.url,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -415,3 +415,77 @@ export interface MCPClientConfig {
   /** Request timeout in milliseconds */
   timeout?: number;
 }
+
+// ============================================================================
+// Test Environment Layer Types (#16, #66)
+// ============================================================================
+
+/**
+ * A single contact_types entry from /api/v1/settings
+ */
+export interface ContactTypeConfig {
+  id: string;
+  parents?: string[];
+  person?: boolean;
+}
+
+/**
+ * A role entry from settings.roles, keyed by role name
+ */
+export interface RoleConfig {
+  name?: string;
+  offline?: boolean;
+}
+
+/**
+ * A transition entry from settings.transitions
+ */
+export type TransitionConfig = boolean | { disable?: boolean };
+
+/**
+ * Deployed configuration discovered from a running CHT instance
+ */
+export interface DiscoveredConfig {
+  contactTypes: ContactTypeConfig[];
+  roles: Record<string, RoleConfig>;
+  permissions: Record<string, string[]>;
+  transitions: Record<string, TransitionConfig>;
+  forms: string[];
+}
+
+/**
+ * Inputs to provision an environment (need a local code path OR a published version)
+ */
+export interface ProvisionOptions {
+  chtCorePath?: string;
+  version?: string;
+  network?: string;
+}
+
+/**
+ * Handle to a provisioned, reachable CHT environment
+ */
+export interface EnvironmentHandle {
+  url: string;
+  auth: { user: string; password: string };
+  network: string;
+  /** Working copy backing this env (set when source-built; needed by applyConfig/rebuild) */
+  chtCorePath?: string;
+  source: 'mock' | 'docker';
+}
+
+/**
+ * Result of seeding test data into the environment
+ */
+export interface TestDataResult {
+  placesCreated: number;
+  peopleCreated: number;
+  reportsCreated: number;
+  usersCreated: number;
+  warnings: string[];
+}
+
+/**
+ * Reset granularity (see Test Environment Layer recommendation, three-tier reset)
+ */
+export type ResetTier = 'couchdb' | 'restart' | 'full';

--- a/test/agents/test-environment-agent.spec.ts
+++ b/test/agents/test-environment-agent.spec.ts
@@ -1,0 +1,255 @@
+import { expect } from 'chai';
+import { TestEnvironmentAgent } from '../../src/agents/test-environment-agent';
+import { DiscoveredConfig, EnvironmentHandle, ProvisionOptions, ResetTier } from '../../src/types';
+
+describe('TestEnvironmentAgent', () => {
+  let agent: TestEnvironmentAgent;
+
+  beforeEach(() => {
+    agent = new TestEnvironmentAgent({ useMockDocker: true });
+  });
+
+  // Helper: provision a mock environment for downstream method tests
+  const provisionMock = (overrides: Partial<ProvisionOptions> = {}): Promise<EnvironmentHandle> =>
+    agent.provision({ chtCorePath: '/workspace/cht-core', ...overrides });
+
+  describe('constructor', () => {
+    it('should default to mock mode when no options are given', () => {
+      const defaultAgent = new TestEnvironmentAgent();
+
+      expect((defaultAgent as any).useMockDocker).to.equal(true);
+    });
+
+    it('should default to mock mode when useMockDocker is omitted', () => {
+      const partialAgent = new TestEnvironmentAgent({});
+
+      expect((partialAgent as any).useMockDocker).to.equal(true);
+    });
+
+    it('should disable mock mode when useMockDocker is false', () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+
+      expect((realAgent as any).useMockDocker).to.equal(false);
+    });
+  });
+
+  describe('provision', () => {
+    it('should return an environment handle from local code path', async () => {
+      const handle = await agent.provision({ chtCorePath: '/workspace/cht-core' });
+
+      expect(handle.url).to.be.a('string').and.not.empty;
+      expect(handle.auth).to.have.keys(['user', 'password']);
+      expect(handle.network).to.be.a('string').and.not.empty;
+      expect(handle.source).to.equal('mock');
+    });
+
+    it('should return an environment handle from a published version', async () => {
+      const handle = await agent.provision({ version: '4.18.0' });
+
+      expect(handle.source).to.equal('mock');
+      expect(handle.chtCorePath).to.equal(undefined);
+    });
+
+    it('should carry chtCorePath on the handle when built from local code', async () => {
+      const handle = await agent.provision({ chtCorePath: '/workspace/cht-core' });
+
+      expect(handle.chtCorePath).to.equal('/workspace/cht-core');
+    });
+
+    it('should honor a network override', async () => {
+      const handle = await agent.provision({ version: '4.18.0', network: 'custom-net' });
+
+      expect(handle.network).to.equal('custom-net');
+    });
+
+    it('should throw when neither chtCorePath nor version is provided', async () => {
+      try {
+        await agent.provision({});
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('requires either chtCorePath or version');
+      }
+    });
+
+    it('should throw not-implemented in real mode', async () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+
+      try {
+        await realAgent.provision({ chtCorePath: '/workspace/cht-core' });
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('not yet implemented');
+      }
+    });
+  });
+
+  describe('applyConfig', () => {
+    it('should resolve in mock mode with the default config path', async () => {
+      const handle = await provisionMock();
+
+      await agent.applyConfig(handle);
+    });
+
+    it('should resolve in mock mode with an explicit config path', async () => {
+      const handle = await provisionMock();
+
+      await agent.applyConfig(handle, 'config/standard');
+    });
+
+    it('should throw not-implemented in real mode', async () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+      const handle: EnvironmentHandle = {
+        url: 'https://nginx',
+        auth: { user: 'medic', password: 'password' },
+        network: 'cht-agent-net',
+        source: 'docker',
+      };
+
+      try {
+        await realAgent.applyConfig(handle);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('not yet implemented');
+      }
+    });
+  });
+
+  describe('discoverConfig', () => {
+    it('should return a discovered config with contact types, roles, and forms', async () => {
+      const handle = await provisionMock();
+
+      const config = await agent.discoverConfig(handle);
+
+      expect(config.contactTypes).to.be.an('array').with.length.greaterThan(0);
+      expect(config.roles).to.be.an('object');
+      expect(Object.keys(config.roles)).to.have.length.greaterThan(0);
+      expect(config.forms).to.be.an('array').with.length.greaterThan(0);
+    });
+
+    it('should include a person contact type in the hierarchy', async () => {
+      const handle = await provisionMock();
+
+      const config = await agent.discoverConfig(handle);
+
+      expect(config.contactTypes.some(ct => ct.person === true)).to.equal(true);
+    });
+
+    it('should throw not-implemented in real mode', async () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+      const handle: EnvironmentHandle = {
+        url: 'https://nginx',
+        auth: { user: 'medic', password: 'password' },
+        network: 'cht-agent-net',
+        source: 'docker',
+      };
+
+      try {
+        await realAgent.discoverConfig(handle);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('not yet implemented');
+      }
+    });
+  });
+
+  describe('prepareTestData', () => {
+    const sampleConfig: DiscoveredConfig = {
+      contactTypes: [{ id: 'clinic' }, { id: 'person', person: true }],
+      roles: { chw: { offline: true } },
+      permissions: {},
+      transitions: {},
+      forms: ['assessment'],
+    };
+
+    it('should return a test data result with numeric counts', async () => {
+      const handle = await provisionMock();
+
+      const result = await agent.prepareTestData(handle, sampleConfig);
+
+      expect(result.placesCreated).to.be.a('number');
+      expect(result.peopleCreated).to.be.a('number');
+      expect(result.reportsCreated).to.be.a('number');
+      expect(result.usersCreated).to.be.a('number');
+      expect(result.warnings).to.be.an('array');
+    });
+
+    it('should report no warnings for a successful mock seed', async () => {
+      const handle = await provisionMock();
+
+      const result = await agent.prepareTestData(handle, sampleConfig);
+
+      expect(result.warnings).to.have.lengthOf(0);
+    });
+
+    it('should throw not-implemented in real mode', async () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+      const handle: EnvironmentHandle = {
+        url: 'https://nginx',
+        auth: { user: 'medic', password: 'password' },
+        network: 'cht-agent-net',
+        source: 'docker',
+      };
+
+      try {
+        await realAgent.prepareTestData(handle, sampleConfig);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('not yet implemented');
+      }
+    });
+  });
+
+  describe('reset', () => {
+    const tiers: ResetTier[] = ['couchdb', 'restart', 'full'];
+
+    tiers.forEach(tier => {
+      it(`should resolve in mock mode for the "${tier}" tier`, async () => {
+        const handle = await provisionMock();
+
+        await agent.reset(handle, tier);
+      });
+    });
+
+    it('should throw not-implemented in real mode', async () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+      const handle: EnvironmentHandle = {
+        url: 'https://nginx',
+        auth: { user: 'medic', password: 'password' },
+        network: 'cht-agent-net',
+        source: 'docker',
+      };
+
+      try {
+        await realAgent.reset(handle, 'full');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('not yet implemented');
+      }
+    });
+  });
+
+  describe('teardown', () => {
+    it('should resolve in mock mode', async () => {
+      const handle = await provisionMock();
+
+      await agent.teardown(handle);
+    });
+
+    it('should throw not-implemented in real mode', async () => {
+      const realAgent = new TestEnvironmentAgent({ useMockDocker: false });
+      const handle: EnvironmentHandle = {
+        url: 'https://nginx',
+        auth: { user: 'medic', password: 'password' },
+        network: 'cht-agent-net',
+        source: 'docker',
+      };
+
+      try {
+        await realAgent.teardown(handle);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('not yet implemented');
+      }
+    });
+  });
+});

--- a/test/agents/test-environment-agent.spec.ts
+++ b/test/agents/test-environment-agent.spec.ts
@@ -39,7 +39,7 @@ describe('TestEnvironmentAgent', () => {
 
       expect(handle.url).to.be.a('string').and.not.empty;
       expect(handle.auth).to.have.keys(['user', 'password']);
-      expect(handle.network).to.be.a('string').and.not.empty;
+      expect(handle.network).to.equal('cht-agent-net'); // default branch (no network override)
       expect(handle.source).to.equal('mock');
     });
 
@@ -120,10 +120,13 @@ describe('TestEnvironmentAgent', () => {
 
       const config = await agent.discoverConfig(handle);
 
-      expect(config.contactTypes).to.be.an('array').with.length.greaterThan(0);
-      expect(config.roles).to.be.an('object');
-      expect(Object.keys(config.roles)).to.have.length.greaterThan(0);
-      expect(config.forms).to.be.an('array').with.length.greaterThan(0);
+      expect(config.contactTypes).to.have.lengthOf(4);
+      expect(Object.keys(config.roles)).to.have.members(['chw', 'supervisor']);
+      expect(config.forms).to.deep.equal(['delivery', 'pregnancy', 'assessment']);
+      expect(config.permissions.can_edit).to.deep.equal(['chw', 'supervisor']);
+      // transitions exercises both arms of the TransitionConfig union
+      expect(config.transitions.update_clinics).to.equal(true);
+      expect(config.transitions.death_reporting).to.deep.equal({ disable: false });
     });
 
     it('should include a person contact type in the hierarchy', async () => {
@@ -132,6 +135,19 @@ describe('TestEnvironmentAgent', () => {
       const config = await agent.discoverConfig(handle);
 
       expect(config.contactTypes.some(ct => ct.person === true)).to.equal(true);
+    });
+
+    it('should return an isolated copy (mutation does not leak to later calls)', async () => {
+      const handle = await provisionMock();
+
+      const first = await agent.discoverConfig(handle);
+      first.forms.push('INJECTED');
+      first.contactTypes.push({ id: 'INJECTED' });
+
+      const second = await agent.discoverConfig(handle);
+
+      expect(second.forms).to.deep.equal(['delivery', 'pregnancy', 'assessment']);
+      expect(second.contactTypes).to.have.lengthOf(4);
     });
 
     it('should throw not-implemented in real mode', async () => {
@@ -161,24 +177,29 @@ describe('TestEnvironmentAgent', () => {
       forms: ['assessment'],
     };
 
-    it('should return a test data result with numeric counts', async () => {
+    it('should return the deterministic seeded counts', async () => {
       const handle = await provisionMock();
 
       const result = await agent.prepareTestData(handle, sampleConfig);
 
-      expect(result.placesCreated).to.be.a('number');
-      expect(result.peopleCreated).to.be.a('number');
-      expect(result.reportsCreated).to.be.a('number');
-      expect(result.usersCreated).to.be.a('number');
-      expect(result.warnings).to.be.an('array');
+      expect(result.placesCreated).to.equal(3);
+      expect(result.peopleCreated).to.equal(5);
+      expect(result.reportsCreated).to.equal(4);
+      expect(result.usersCreated).to.equal(2);
+      expect(result.warnings).to.deep.equal([]);
     });
 
-    it('should report no warnings for a successful mock seed', async () => {
+    it('should return an isolated copy (mutation does not leak to later calls)', async () => {
       const handle = await provisionMock();
 
-      const result = await agent.prepareTestData(handle, sampleConfig);
+      const first = await agent.prepareTestData(handle, sampleConfig);
+      first.warnings.push('leak');
+      first.placesCreated = 999;
 
-      expect(result.warnings).to.have.lengthOf(0);
+      const second = await agent.prepareTestData(handle, sampleConfig);
+
+      expect(second.warnings).to.deep.equal([]);
+      expect(second.placesCreated).to.equal(3);
     });
 
     it('should throw not-implemented in real mode', async () => {

--- a/test/agents/test-environment-agent.spec.ts
+++ b/test/agents/test-environment-agent.spec.ts
@@ -87,13 +87,13 @@ describe('TestEnvironmentAgent', () => {
     it('should resolve in mock mode with the default config path', async () => {
       const handle = await provisionMock();
 
-      await agent.applyConfig(handle);
+      expect(await agent.applyConfig(handle)).to.equal(undefined);
     });
 
     it('should resolve in mock mode with an explicit config path', async () => {
       const handle = await provisionMock();
 
-      await agent.applyConfig(handle, 'config/standard');
+      expect(await agent.applyConfig(handle, 'config/standard')).to.equal(undefined);
     });
 
     it('should throw not-implemented in real mode', async () => {
@@ -227,7 +227,7 @@ describe('TestEnvironmentAgent', () => {
       it(`should resolve in mock mode for the "${tier}" tier`, async () => {
         const handle = await provisionMock();
 
-        await agent.reset(handle, tier);
+        expect(await agent.reset(handle, tier)).to.equal(undefined);
       });
     });
 
@@ -253,7 +253,7 @@ describe('TestEnvironmentAgent', () => {
     it('should resolve in mock mode', async () => {
       const handle = await provisionMock();
 
-      await agent.teardown(handle);
+      expect(await agent.teardown(handle)).to.equal(undefined);
     });
 
     it('should throw not-implemented in real mode', async () => {


### PR DESCRIPTION
## Description

- Add `TestEnvironmentAgent` (Test Environment Layer, under the QA Supervisor) with deterministic **mock mode** mirroring the other agents — six methods: `provision`, `applyConfig`, `discoverConfig`, `prepareTestData`, `reset`, `teardown`. Mock paths return cloned fixtures; real mode throws "not yet implemented".
- Add Test Environment Layer types to `src/types/index.ts`: `DiscoveredConfig` (+ `ContactTypeConfig`, `RoleConfig`, `TransitionConfig`), `ProvisionOptions`, `EnvironmentHandle`, `TestDataResult`, `ResetTier`.
- Add `src/agents/test-environment-agent.mock-data.ts` fixtures (returned by value via `structuredClone` so callers can't poison the singleton).
- Add `test/agents/test-environment-agent.spec.ts` (18 specs): constructor, provision (input validation + network default), applyConfig, discoverConfig, prepareTestData, reset tiers, teardown, mock-fixture isolation, and real-mode not-implemented guards.
- Scope: no real Docker/cht-conf orchestration, CLI, or LangGraph node — those are #66. Per the #16 redesign, this layer applies/discovers config and generates test data; it does not author app config.

Closes #43

## Code review checklist

- [x] Readable: Concise, well named, follows the style guide, documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate

## License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
