### PR TITLE
feat(#114): dockerize cht-agent with git/credential sandbox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Build context for docker/Dockerfile (context is the repo root).
+# agent-memory/ is intentionally INCLUDED — it is the context database the
+# agent reads at runtime.
+.git
+.claude
+.idea
+node_modules
+dist
+coverage
+.nyc_output
+outputs
+*.log
+.env
+.DS_Store
+*.tmp
+*.bak

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,55 +8,42 @@
 
 FROM node:22-bookworm
 
-# Tools the agent drives. openssh-client is purged: all remote reads go over
-# HTTPS, and without an ssh binary git ssh:// URLs fail closed.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    curl \
-    bash \
-    jq \
-    build-essential \
-    python3 \
-    ca-certificates \
-    && apt-get purge -y openssh-client 2>/dev/null || true \
-    && rm -rf /var/lib/apt/lists/* \
-    && ! command -v ssh   # fail the build closed if an ssh binary survived
-
-# cht-conf baked in: the Test Environment Layer (#66) runs the `cht` binary
-# against a CHT instance over HTTP — no Docker needed inside the container.
-RUN npm install -g cht-conf
-
-# --- Git sandbox layer 2: push hard-blocked at system git config ---
-# pushInsteadOf rewrites only PUSH urls, so fetch/clone of public repos stays
-# allowed. System-level config requires root to change; the agent user cannot.
-# --add is required: pushInsteadOf is multi-valued, and a plain `git config`
-# set would clobber to the last value, silently dropping the https rewrite.
+# Root-level setup in one layer: tools the agent drives, the system-level git
+# push block, and removal of all ssh client config.
+# - openssh-client is purged so git ssh:// URLs fail closed (reads use HTTPS);
+#   the trailing `! command -v ssh` fails the build closed if ssh survived.
+# - pushInsteadOf rewrites only PUSH urls, so fetch/clone of public repos stays
+#   allowed; system config needs root, which the agent user lacks. --add is
+#   required (pushInsteadOf is multi-valued; a plain set drops the https value).
 # (Adapted from the cht-core PoC .devcontainer: "no remote at all" became
 # "remote read OK, push blocked".)
-RUN git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "git@github.com:" && \
-    git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "https://github.com/" && \
-    git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "ssh://git@github.com/" && \
-    git config --system push.default nothing && \
-    git config --system credential.helper "" && \
-    git config --system transfer.fsckObjects true
-
-# No SSH client config anywhere in the image
-RUN rm -rf /root/.ssh /etc/ssh/ssh_config.d
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl bash jq build-essential python3 ca-certificates \
+    && { apt-get purge -y openssh-client 2>/dev/null || true; } \
+    && rm -rf /var/lib/apt/lists/* \
+    && ! command -v ssh \
+    && npm install -g cht-conf \
+    && git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "git@github.com:" \
+    && git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "https://github.com/" \
+    && git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "ssh://git@github.com/" \
+    && git config --system push.default nothing \
+    && git config --system credential.helper "" \
+    && git config --system transfer.fsckObjects true \
+    && rm -rf /root/.ssh /etc/ssh/ssh_config.d
 
 # --- Git sandbox layer 1: non-root user, no credentials ---
 # AGENT_UID must match the host user that owns the cht-core working copy so the
 # bind mount is writable both ways (override with --build-arg AGENT_UID=$(id -u)).
-# The node base image owns uid 1000 — remove it before reusing the uid.
+# The node base image owns uid 1000 — remove it before reusing the uid. The
+# root-owned, read-only ~/.ssh stops the agent adding keys or ssh config.
 ARG AGENT_UID=1000
-RUN userdel -r node 2>/dev/null || true && \
-    useradd -m -s /bin/bash -u "${AGENT_UID}" agent
-
-# Root-owned, read-only ~/.ssh so the agent cannot add keys or ssh config.
-RUN mkdir -p /home/agent/.ssh && \
-    echo "# SSH disabled for the cht-agent sandbox" > /home/agent/.ssh/config && \
-    chmod 444 /home/agent/.ssh/config && \
-    chmod 555 /home/agent/.ssh && \
-    chown -R root:root /home/agent/.ssh
+RUN { userdel -r node 2>/dev/null || true; } \
+    && useradd -m -s /bin/bash -u "${AGENT_UID}" agent \
+    && mkdir -p /home/agent/.ssh \
+    && echo "# SSH disabled for the cht-agent sandbox" > /home/agent/.ssh/config \
+    && chmod 444 /home/agent/.ssh/config \
+    && chmod 555 /home/agent/.ssh \
+    && chown -R root:root /home/agent/.ssh
 
 # --- App build ---
 WORKDIR /app
@@ -64,21 +51,23 @@ WORKDIR /app
 ENV HUSKY=0
 COPY package.json package-lock.json ./
 RUN npm ci
-COPY . .
-RUN npm run build && chown -R agent:agent /app
-
-# Mount points: the cht-core working copy is an INPUT (a standing local clone
-# the agent branches locally and edits in place — it never clones or pushes it).
-RUN mkdir -p /workspace/cht-core /home/agent/.claude && \
-    chown -R agent:agent /workspace /home/agent/.claude
+# Copy only what the build (src + tsconfig) and runtime (agent-memory, tickets)
+# need — not the whole context — so no stray or sensitive files enter the image.
+COPY tsconfig.json ./
+COPY src ./src
+COPY agent-memory ./agent-memory
+COPY tickets ./tickets
+RUN npm run build \
+    && mkdir -p /workspace/cht-core /home/agent/.claude \
+    && chown -R agent:agent /app /workspace /home/agent/.claude
 
 # Sandbox init (layer 4) + agent-session rules (layer 5)
 COPY docker/scripts/agent-entrypoint.sh /usr/local/bin/agent-entrypoint.sh
 COPY docker/scripts/init-agent-git.sh /usr/local/bin/init-agent-git.sh
 COPY docker/agent/CLAUDE.md /home/agent/.claude/CLAUDE.md
 COPY docker/agent/settings.json /home/agent/.claude/settings.json
-RUN chmod 755 /usr/local/bin/agent-entrypoint.sh /usr/local/bin/init-agent-git.sh && \
-    chown agent:agent /home/agent/.claude/CLAUDE.md /home/agent/.claude/settings.json
+RUN chmod 755 /usr/local/bin/agent-entrypoint.sh /usr/local/bin/init-agent-git.sh \
+    && chown agent:agent /home/agent/.claude/CLAUDE.md /home/agent/.claude/settings.json
 
 # --- Extension point: code-generation tools (deferred — see #114) ---
 # The tool set is still being decided. When chosen, bake tools here (above
@@ -91,11 +80,11 @@ USER agent
 # Layer 4 (defense in depth): dummy identity — init-agent-git.sh also exports
 # it via environment on every start. safe.directory: the bind-mounted working
 # copy is owned by the host uid.
-RUN git config --global user.name "CHT Agent" && \
-    git config --global user.email "agent@cht-agent.local" && \
-    git config --global credential.helper "" && \
-    git config --global push.default nothing && \
-    git config --global --add safe.directory /workspace/cht-core
+RUN git config --global user.name "CHT Agent" \
+    && git config --global user.email "agent@cht-agent.local" \
+    && git config --global credential.helper "" \
+    && git config --global push.default nothing \
+    && git config --global --add safe.directory /workspace/cht-core
 
 ENV CLAUDE_CONFIG_DIR=/home/agent/.claude
 ENV CHT_CORE_PATH=/workspace/cht-core

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,9 @@
 # human-gated on the host (see docs/docker-agent-runbook.md and
 # designs/layer_recommendations/test-environment-layer.md).
 
+# Pinned to the major+distro tag, not a digest: this is a locally-rebuilt dev
+# sandbox (image: cht-agent:local), so we want OS security patches on each
+# rebuild. Pin to a @sha256 digest if you need byte-reproducible builds.
 FROM node:22-bookworm
 
 # Root-level setup in one layer: tools the agent drives, the system-level git
@@ -74,6 +77,9 @@ RUN chmod 755 /usr/local/bin/agent-entrypoint.sh /usr/local/bin/init-agent-git.s
 # `USER agent` so they install system-wide), e.g.:
 #   RUN npm install -g @anthropic-ai/claude-code
 # Tools must respect the sandbox: no credentials baked, no Docker required.
+# NOTE: the ~/.claude/settings.json allow/deny lists and the .credentials.json
+# mount only take runtime effect once such a CLI is the execution layer — until
+# then they are inert. Re-audit both when this extension point is filled.
 
 USER agent
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,111 @@
+# cht-agent sandboxed image (#114)
+#
+# Bakes in the tools the agent drives (cht-conf today; code-generation tools
+# later) and hardens git so autonomous loops can READ public remotes but never
+# push. The container has no Docker access — CHT environment bring-up is
+# human-gated on the host (see docs/docker-agent-runbook.md and
+# designs/layer_recommendations/test-environment-layer.md).
+
+FROM node:22-bookworm
+
+# Tools the agent drives. openssh-client is purged: all remote reads go over
+# HTTPS, and without an ssh binary git ssh:// URLs fail closed.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    bash \
+    jq \
+    build-essential \
+    python3 \
+    ca-certificates \
+    && apt-get purge -y openssh-client 2>/dev/null || true \
+    && rm -rf /var/lib/apt/lists/* \
+    && ! command -v ssh   # fail the build closed if an ssh binary survived
+
+# cht-conf baked in: the Test Environment Layer (#66) runs the `cht` binary
+# against a CHT instance over HTTP — no Docker needed inside the container.
+RUN npm install -g cht-conf
+
+# --- Git sandbox layer 2: push hard-blocked at system git config ---
+# pushInsteadOf rewrites only PUSH urls, so fetch/clone of public repos stays
+# allowed. System-level config requires root to change; the agent user cannot.
+# --add is required: pushInsteadOf is multi-valued, and a plain `git config`
+# set would clobber to the last value, silently dropping the https rewrite.
+# (Adapted from the cht-core PoC .devcontainer: "no remote at all" became
+# "remote read OK, push blocked".)
+RUN git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "git@github.com:" && \
+    git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "https://github.com/" && \
+    git config --system --add url."error://push-blocked-by-policy".pushInsteadOf "ssh://git@github.com/" && \
+    git config --system push.default nothing && \
+    git config --system credential.helper "" && \
+    git config --system transfer.fsckObjects true
+
+# No SSH client config anywhere in the image
+RUN rm -rf /root/.ssh /etc/ssh/ssh_config.d
+
+# --- Git sandbox layer 1: non-root user, no credentials ---
+# AGENT_UID must match the host user that owns the cht-core working copy so the
+# bind mount is writable both ways (override with --build-arg AGENT_UID=$(id -u)).
+# The node base image owns uid 1000 — remove it before reusing the uid.
+ARG AGENT_UID=1000
+RUN userdel -r node 2>/dev/null || true && \
+    useradd -m -s /bin/bash -u "${AGENT_UID}" agent
+
+# Root-owned, read-only ~/.ssh so the agent cannot add keys or ssh config.
+RUN mkdir -p /home/agent/.ssh && \
+    echo "# SSH disabled for the cht-agent sandbox" > /home/agent/.ssh/config && \
+    chmod 444 /home/agent/.ssh/config && \
+    chmod 555 /home/agent/.ssh && \
+    chown -R root:root /home/agent/.ssh
+
+# --- App build ---
+WORKDIR /app
+# husky's postinstall needs a .git directory; HUSKY=0 skips hook installation.
+ENV HUSKY=0
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build && chown -R agent:agent /app
+
+# Mount points: the cht-core working copy is an INPUT (a standing local clone
+# the agent branches locally and edits in place — it never clones or pushes it).
+RUN mkdir -p /workspace/cht-core /home/agent/.claude && \
+    chown -R agent:agent /workspace /home/agent/.claude
+
+# Sandbox init (layer 4) + agent-session rules (layer 5)
+COPY docker/scripts/agent-entrypoint.sh /usr/local/bin/agent-entrypoint.sh
+COPY docker/scripts/init-agent-git.sh /usr/local/bin/init-agent-git.sh
+COPY docker/agent/CLAUDE.md /home/agent/.claude/CLAUDE.md
+COPY docker/agent/settings.json /home/agent/.claude/settings.json
+RUN chmod 755 /usr/local/bin/agent-entrypoint.sh /usr/local/bin/init-agent-git.sh && \
+    chown agent:agent /home/agent/.claude/CLAUDE.md /home/agent/.claude/settings.json
+
+# --- Extension point: code-generation tools (deferred — see #114) ---
+# The tool set is still being decided. When chosen, bake tools here (above
+# `USER agent` so they install system-wide), e.g.:
+#   RUN npm install -g @anthropic-ai/claude-code
+# Tools must respect the sandbox: no credentials baked, no Docker required.
+
+USER agent
+
+# Layer 4 (defense in depth): dummy identity — init-agent-git.sh also exports
+# it via environment on every start. safe.directory: the bind-mounted working
+# copy is owned by the host uid.
+RUN git config --global user.name "CHT Agent" && \
+    git config --global user.email "agent@cht-agent.local" && \
+    git config --global credential.helper "" && \
+    git config --global push.default nothing && \
+    git config --global --add safe.directory /workspace/cht-core
+
+ENV CLAUDE_CONFIG_DIR=/home/agent/.claude
+ENV CHT_CORE_PATH=/workspace/cht-core
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
+# Reinforces the sandbox at runtime: unhealthy if cht-conf vanished or an ssh
+# binary ever appeared (the idle `sleep infinity` container is otherwise opaque).
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 \
+  CMD command -v cht > /dev/null && ! command -v ssh > /dev/null
+
+# Entrypoint verifies every sandbox layer, then idles for `docker exec`.
+ENTRYPOINT ["/usr/local/bin/agent-entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/docker/agent/CLAUDE.md
+++ b/docker/agent/CLAUDE.md
@@ -1,0 +1,42 @@
+# cht-agent Sandbox Rules
+
+You are running inside the sandboxed cht-agent container (issue #114). These
+rules are one layer of a multi-layer sandbox — the others are enforced at the
+image and compose level, so violating them will fail anyway. Don't try.
+
+## Git
+
+- **Reading remotes is fine.** `git clone`, `git fetch`, and `git pull` of
+  public repositories (cht-core, cht-agent, cht-conf, ...) are allowed and
+  expected.
+- **Never `git push`.** All work stays on local branches. The host user
+  reviews and owns every push and every PR. Pushes are hard-blocked at the
+  system git config and there are no write credentials in this container —
+  do not attempt to work around that.
+- **Never change a remote.** No `git remote set-url`, `git remote add`, or
+  editing `.git/config` (it is mounted read-only in the working copy).
+- Work on the cht-core working copy at `$CHT_CORE_PATH` (`/workspace/cht-core`):
+  create a local branch off `main`, commit locally as you go.
+
+## Docker
+
+- **You cannot and must not run Docker.** There is no socket and no binary.
+  CHT environment bring-up, image builds (`npm run local-images`), and
+  teardown are performed by the human operator. Request a bring-up and poll
+  `GET $CHT_URL/api/v2/monitoring` until healthy.
+- The one reset you may do yourself is CouchDB-tier wipe/reseed over the
+  CouchDB HTTP API.
+
+## Network
+
+- The only external network access you need is the CHT instance on
+  `cht-agent-net` (default `https://nginx`, self-signed TLS) and read-only
+  HTTPS to public git hosts and the npm registry. Do not reach for anything
+  else.
+
+## Tools
+
+- `cht` (cht-conf) is installed globally — use it over HTTP with
+  `--url=$CHT_URL` (no Docker required).
+- The cht-agent app lives at `/app` (built); its CLI entry points are the
+  `npm run` scripts defined there.

--- a/docker/agent/settings.json
+++ b/docker/agent/settings.json
@@ -32,6 +32,8 @@
       "Bash(git remote remove:*)",
       "Bash(git remote rename:*)",
       "Bash(git config --system:*)",
+      "Bash(git config --global:*)",
+      "Bash(git config --local:*)",
       "Bash(ssh:*)",
       "Bash(scp:*)",
       "Bash(sftp:*)",

--- a/docker/agent/settings.json
+++ b/docker/agent/settings.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(node:*)",
+      "Bash(cht:*)",
+      "Bash(curl:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git restore:*)",
+      "Bash(git branch:*)",
+      "Bash(git stash:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+      "Bash(git clone:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pull:*)",
+      "Bash(git remote -v)",
+      "Bash(git remote show:*)"
+    ],
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(git remote set-url:*)",
+      "Bash(git remote add:*)",
+      "Bash(git remote remove:*)",
+      "Bash(git remote rename:*)",
+      "Bash(git config --system:*)",
+      "Bash(ssh:*)",
+      "Bash(scp:*)",
+      "Bash(sftp:*)",
+      "Bash(rm -rf:*)",
+      "Bash(docker:*)",
+      "Bash(docker-compose:*)",
+      "Bash(sudo:*)",
+      "Bash(su:*)"
+    ]
+  }
+}

--- a/docker/docker-compose.cht-agent.yml
+++ b/docker/docker-compose.cht-agent.yml
@@ -58,13 +58,17 @@ services:
       - ${CHT_CORE_PATH:?Set CHT_CORE_PATH to your cht-core working copy}:/workspace/cht-core:rw
       # Hardened git config shadows the working copy's own .git/config.
       - ${CHT_CORE_GIT_CONFIG:-./git-config.hardened}:/workspace/cht-core/.git/config:ro
-      # Model credentials, read-only. The file MUST exist as a regular file
-      # before `up` (run bootstrap-workspace.sh, which touches it) — otherwise
-      # Docker creates a root-owned directory at the target. Compose does NOT
-      # expand `~`, so the default uses ${HOME}; set CLAUDE_CREDENTIALS to an
-      # absolute path to override. NOTE: whatever is mounted here is fully
-      # readable by the agent's shell — use a disposable, narrowly-scoped key,
-      # never your personal OAuth credentials (see docs/docker-agent-runbook.md).
+      # Model credentials, read-only. CURRENTLY UNUSED: the base image bakes no
+      # OAuth-based CLI yet (deferred code-gen extension point), and the seeding
+      # pipeline authenticates via its own named volume (docker-compose.seeder.yml),
+      # not this bind. It stays as the hook for when a Claude-CLI-style tool lands.
+      # Today the agent authenticates with ANTHROPIC_API_KEY (above).
+      # The file MUST exist as a regular file before `up` (run bootstrap-workspace.sh,
+      # which touches it) — otherwise Docker creates a root-owned directory at the
+      # target. Compose does NOT expand `~`, so the default uses ${HOME}; set
+      # CLAUDE_CREDENTIALS to an absolute path to override. NOTE: whatever is mounted
+      # here is fully readable by the agent's shell — use a disposable, narrowly-scoped
+      # key, never your personal OAuth credentials (see docs/docker-agent-runbook.md).
       - ${CLAUDE_CREDENTIALS:-${HOME}/.claude/.credentials.json}:/home/agent/.claude/.credentials.json:ro
     deploy:
       resources:

--- a/docker/docker-compose.cht-agent.yml
+++ b/docker/docker-compose.cht-agent.yml
@@ -1,0 +1,73 @@
+# docker-compose.cht-agent.yml (#114)
+#
+# Runs the sandboxed cht-agent on the shared `cht-agent-net` Docker network,
+# alongside a CHT instance the HUMAN operator brings up (the agent never runs
+# Docker). The #66 override (docker/cht-agent-net.override.yml) attaches the
+# CHT stack's nginx to the same network so the agent reaches it at
+# https://nginx. Full walkthrough: docs/docker-agent-runbook.md.
+#
+#   docker network create cht-agent-net    # once
+#   CHT_CORE_PATH=$HOME/src/cht-core \
+#     docker compose -f docker/docker-compose.cht-agent.yml up -d --build
+#
+# Security invariants (do not "fix" these):
+#   - NO Docker socket mount. A mounted socket grants host-root; env bring-up
+#     is human-gated instead.
+#   - NO SSH keys, host ~/.gitconfig, or write tokens enter the container.
+#   - Model credentials are mounted READ-ONLY.
+#   - The working copy's .git/config is shadowed by a hardened read-only file,
+#     so the agent cannot edit remotes or undo the push block.
+
+networks:
+  cht-agent-net:
+    external: true
+
+services:
+  cht-agent:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: cht-agent:local
+    container_name: cht-agent
+    hostname: cht-agent
+    stdin_open: true
+    tty: true
+    # Operator-gated: a sandbox-verification failure (init-agent-git.sh exits
+    # non-zero) must stay DOWN for inspection, not crash-loop. The operator
+    # explicitly brings the agent up per session.
+    restart: "no"
+    # Confinement hardening: the agent never needs extra privileges.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      - cht-agent-net
+    environment:
+      # Model credentials: pass an API key, or rely on the read-only
+      # .credentials.json mount below (for OAuth-based tools).
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CHT_CORE_PATH: /workspace/cht-core
+      # CHT entry point on cht-agent-net (nginx joins via the #66 override)
+      CHT_URL: ${CHT_URL:-https://nginx}
+      NODE_ENV: development
+    volumes:
+      # The cht-core working copy is an INPUT: a standing local clone the agent
+      # local-branches and edits in place. Must be a full clone (a .git
+      # DIRECTORY — worktrees have a .git file and the shadow mount below fails).
+      - ${CHT_CORE_PATH:?Set CHT_CORE_PATH to your cht-core working copy}:/workspace/cht-core:rw
+      # Hardened git config shadows the working copy's own .git/config.
+      - ${CHT_CORE_GIT_CONFIG:-./git-config.hardened}:/workspace/cht-core/.git/config:ro
+      # Model credentials, read-only. The file MUST exist as a regular file
+      # before `up` (run bootstrap-workspace.sh, which touches it) — otherwise
+      # Docker creates a root-owned directory at the target. Compose does NOT
+      # expand `~`, so the default uses ${HOME}; set CLAUDE_CREDENTIALS to an
+      # absolute path to override. NOTE: whatever is mounted here is fully
+      # readable by the agent's shell — use a disposable, narrowly-scoped key,
+      # never your personal OAuth credentials (see docs/docker-agent-runbook.md).
+      - ${CLAUDE_CREDENTIALS:-${HOME}/.claude/.credentials.json}:/home/agent/.claude/.credentials.json:ro
+    deploy:
+      resources:
+        limits:
+          memory: ${AGENT_MEMORY_LIMIT:-4g}
+          cpus: "${AGENT_CPU_LIMIT:-2}"

--- a/docker/git-config.hardened
+++ b/docker/git-config.hardened
@@ -1,0 +1,30 @@
+# Hardened .git/config for the cht-core working copy mounted into the
+# cht-agent container (#114).
+#
+# Compose mounts this file READ-ONLY over <working copy>/.git/config so the
+# agent cannot edit remotes or undo the push block. Requires the working copy
+# to be a full clone (.git directory); git worktrees have a .git *file* and
+# the shadow mount will fail.
+#
+# Read stays allowed (public repo); push is rewritten to error:// here AND at
+# the image's system-level git config.
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+[remote "origin"]
+	url = https://github.com/medic/cht-core.git
+	pushurl = error://push-blocked-by-policy
+	fetch = +refs/heads/*:refs/remotes/origin/*
+# Upstream tracking for the default branch. Without this, replacing the working
+# copy's .git/config strips all [branch] stanzas and `git pull --ff-only` on
+# main fails with "no tracking information". The agent branches off main, so it
+# needs main to track origin/main.
+[branch "main"]
+	remote = origin
+	merge = refs/heads/main
+[push]
+	default = nothing
+[credential]
+	helper =

--- a/docker/scripts/agent-entrypoint.sh
+++ b/docker/scripts/agent-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Entrypoint for the sandboxed cht-agent container (#114).
+# Verifies the git/credential sandbox on every start, then hands off to CMD
+# (default: sleep infinity, so the operator can `docker exec` the pipeline CLI).
+set -euo pipefail
+
+/usr/local/bin/init-agent-git.sh
+
+exec "$@"

--- a/docker/scripts/bootstrap-workspace.sh
+++ b/docker/scripts/bootstrap-workspace.sh
@@ -22,15 +22,15 @@ echo "[bootstrap] cht-core working copy: $CHT_CORE_PATH"
 
 # 1. Provide the working copy (public repo, read-only use — the agent
 # local-branches off main; only the operator ever pushes).
-if [ ! -e "$CHT_CORE_PATH" ]; then
+if [[ ! -e "$CHT_CORE_PATH" ]]; then
   echo "[bootstrap] Cloning cht-core (this is large; first run takes a while)..."
   git clone "$CHT_CORE_REPO" "$CHT_CORE_PATH"
-elif [ -f "$CHT_CORE_PATH/.git" ]; then
+elif [[ -f "$CHT_CORE_PATH/.git" ]]; then
   # A worktree's .git is a FILE — the read-only config shadow mount needs a directory.
   echo "[bootstrap] ERROR: $CHT_CORE_PATH is a git worktree (.git is a file)." >&2
   echo "[bootstrap] Use a full clone — the hardened .git/config mount requires a .git directory." >&2
   exit 1
-elif [ ! -d "$CHT_CORE_PATH/.git" ]; then
+elif [[ ! -d "$CHT_CORE_PATH/.git" ]]; then
   echo "[bootstrap] ERROR: $CHT_CORE_PATH exists but is not a git repository." >&2
   exit 1
 fi
@@ -54,7 +54,7 @@ fi
 # or Docker creates a root-owned directory there and the agent gets EISDIR. An
 # empty file is harmless when you authenticate with ANTHROPIC_API_KEY instead.
 CREDS_PATH="${CLAUDE_CREDENTIALS:-$HOME/.claude/.credentials.json}"
-if [ ! -f "$CREDS_PATH" ]; then
+if [[ ! -f "$CREDS_PATH" ]]; then
   mkdir -p "$(dirname "$CREDS_PATH")"
   touch "$CREDS_PATH"
   echo "[bootstrap] Created empty credentials mount target: $CREDS_PATH"

--- a/docker/scripts/bootstrap-workspace.sh
+++ b/docker/scripts/bootstrap-workspace.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Host-side workspace bootstrap for the dockerized cht-agent (#114, #66 follow-up).
+#
+# Run by the OPERATOR before `docker compose up` — never inside the container.
+# Cloning cannot happen in the container: compose shadow-mounts the hardened
+# git config over <working copy>/.git/config read-only, which requires a .git
+# directory to exist at the mount target before the container starts.
+#
+#   docker/scripts/bootstrap-workspace.sh [path-to-cht-core]
+#
+# Idempotent: clones cht-core if absent, fast-forwards main if present,
+# ensures cht-agent-net exists, then prints the compose command to run.
+
+set -euo pipefail
+
+CHT_CORE_PATH="${1:-${CHT_CORE_PATH:-$HOME/src/cht-core}}"
+CHT_CORE_REPO="https://github.com/medic/cht-core.git"
+NETWORK="cht-agent-net"
+COMPOSE_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/docker-compose.cht-agent.yml"
+
+echo "[bootstrap] cht-core working copy: $CHT_CORE_PATH"
+
+# 1. Provide the working copy (public repo, read-only use — the agent
+# local-branches off main; only the operator ever pushes).
+if [ ! -e "$CHT_CORE_PATH" ]; then
+  echo "[bootstrap] Cloning cht-core (this is large; first run takes a while)..."
+  git clone "$CHT_CORE_REPO" "$CHT_CORE_PATH"
+elif [ -f "$CHT_CORE_PATH/.git" ]; then
+  # A worktree's .git is a FILE — the read-only config shadow mount needs a directory.
+  echo "[bootstrap] ERROR: $CHT_CORE_PATH is a git worktree (.git is a file)." >&2
+  echo "[bootstrap] Use a full clone — the hardened .git/config mount requires a .git directory." >&2
+  exit 1
+elif [ ! -d "$CHT_CORE_PATH/.git" ]; then
+  echo "[bootstrap] ERROR: $CHT_CORE_PATH exists but is not a git repository." >&2
+  exit 1
+fi
+
+# 2. Fresh main as the base the agent branches from. ff-only: never rewrite
+# or merge over local work — if main has local commits, stop and let the
+# operator decide.
+echo "[bootstrap] Updating main (ff-only)..."
+git -C "$CHT_CORE_PATH" checkout main
+git -C "$CHT_CORE_PATH" pull --ff-only
+
+# 3. Shared network the agent and the CHT stack both join.
+if docker network inspect "$NETWORK" > /dev/null 2>&1; then
+  echo "[bootstrap] Docker network $NETWORK already exists."
+else
+  docker network create "$NETWORK"
+  echo "[bootstrap] Created Docker network $NETWORK."
+fi
+
+# 4. Model-credentials mount target must exist as a regular FILE before `up`,
+# or Docker creates a root-owned directory there and the agent gets EISDIR. An
+# empty file is harmless when you authenticate with ANTHROPIC_API_KEY instead.
+CREDS_PATH="${CLAUDE_CREDENTIALS:-$HOME/.claude/.credentials.json}"
+if [ ! -f "$CREDS_PATH" ]; then
+  mkdir -p "$(dirname "$CREDS_PATH")"
+  touch "$CREDS_PATH"
+  echo "[bootstrap] Created empty credentials mount target: $CREDS_PATH"
+fi
+
+echo
+echo "[bootstrap] Workspace ready. Start the agent with:"
+echo
+echo "  CHT_CORE_PATH=$CHT_CORE_PATH \\"
+echo "    docker compose -f $COMPOSE_FILE up -d --build"

--- a/docker/scripts/init-agent-git.sh
+++ b/docker/scripts/init-agent-git.sh
@@ -23,9 +23,9 @@ set -uo pipefail
 CHT_CORE_PATH="${CHT_CORE_PATH:-/workspace/cht-core}"
 FAILURES=0
 
-ok()   { echo "  [OK]   $1"; }
-warn() { echo "  [WARN] $1"; }
-fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+ok()   { local msg="$1"; echo "  [OK]   $msg"; return 0; }
+warn() { local msg="$1"; echo "  [WARN] $msg"; return 0; }
+fail() { local msg="$1"; echo "  [FAIL] $msg"; FAILURES=$((FAILURES + 1)); return 0; }
 
 echo "[cht-agent] Initializing git/credential sandbox..."
 
@@ -61,7 +61,7 @@ exit 1
 HOOK
   # set -e is intentionally off; if .git/hooks is owned by another uid the
   # write fails silently, so verify and warn rather than assume L4 is up.
-  if [ -f "$HOOKS_DIR/pre-push" ] && chmod +x "$HOOKS_DIR/pre-push" 2>/dev/null; then
+  if [[ -f "$HOOKS_DIR/pre-push" ]] && chmod +x "$HOOKS_DIR/pre-push" 2>/dev/null; then
     ok "pre-push hook installed in working copy"
   else
     warn "could not install pre-push hook (working copy .git owned by another uid?) — L4 degraded; push still blocked by L2/L3"
@@ -85,7 +85,7 @@ for scheme in "https://github.com/" "git@github.com:" "ssh://git@github.com/"; d
     fail "system pushInsteadOf is missing the $scheme rewrite"
   fi
 done
-if [ "$(git config --system push.default 2>/dev/null)" = "nothing" ]; then
+if [[ "$(git config --system push.default 2>/dev/null)" == "nothing" ]]; then
   ok "push.default=nothing"
 else
   fail "push.default is not 'nothing'"
@@ -105,26 +105,26 @@ fi
 TOKENS_FOUND=0
 for tok in GH_TOKEN GITHUB_TOKEN GITHUB_ACCESS_TOKEN GH_ENTERPRISE_TOKEN \
            GIT_TOKEN GITLAB_TOKEN CR_PAT GIT_ASKPASS GIT_USERNAME GIT_PASSWORD; do
-  if [ -n "${!tok:-}" ]; then
+  if [[ -n "${!tok:-}" ]]; then
     fail "$tok is set in the environment"
     TOKENS_FOUND=1
   fi
 done
 for credfile in "$HOME/.netrc" "$HOME/.git-credentials"; do
-  if [ -e "$credfile" ]; then
+  if [[ -e "$credfile" ]]; then
     fail "credential file present: $credfile"
     TOKENS_FOUND=1
   fi
 done
-[ "$TOKENS_FOUND" -eq 0 ] && ok "no git write tokens or credential files (env + ~/.netrc + ~/.git-credentials)"
-if [ "$(git config --system credential.helper 2>/dev/null)" = "" ]; then
+[[ "$TOKENS_FOUND" -eq 0 ]] && ok "no git write tokens or credential files (env + ~/.netrc + ~/.git-credentials)"
+if [[ -z "$(git config --system credential.helper 2>/dev/null)" ]]; then
   ok "no credential helper"
 else
   fail "a credential helper is configured"
 fi
 
 # L1: no Docker access (the agent never runs Docker; bring-up is human-gated)
-if [ -S /var/run/docker.sock ]; then
+if [[ -S /var/run/docker.sock ]]; then
   fail "Docker socket is mounted — this grants host-root; remove it"
 else
   ok "no Docker socket"
@@ -136,8 +136,8 @@ else
 fi
 
 # Working-copy hardening (compose shadows .git/config read-only)
-if [ -e "$CHT_CORE_PATH/.git/config" ]; then
-  if [ -w "$CHT_CORE_PATH/.git/config" ]; then
+if [[ -e "$CHT_CORE_PATH/.git/config" ]]; then
+  if [[ -w "$CHT_CORE_PATH/.git/config" ]]; then
     warn ".git/config is writable — mount the hardened config read-only (see compose)"
   else
     ok "working copy .git/config is read-only"
@@ -153,7 +153,7 @@ fi
 
 echo "  identity = $GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"
 
-if [ "$FAILURES" -gt 0 ]; then
+if [[ "$FAILURES" -gt 0 ]]; then
   echo "[cht-agent] Sandbox verification FAILED ($FAILURES check(s)). Refusing to start."
   exit 1
 fi

--- a/docker/scripts/init-agent-git.sh
+++ b/docker/scripts/init-agent-git.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Initializes and verifies the cht-agent git/credential sandbox (#114).
+# Runs on every container start via agent-entrypoint.sh.
+#
+# Model: remote READ is allowed (cht-core and cht-agent are public repos);
+# remote WRITE is impossible — only the host user pushes. Adapted from the
+# cht-core PoC .devcontainer, which blocked remotes entirely; here fetch/clone
+# stay open and only push is blocked.
+#
+#   1. Exports a dummy git identity via environment (no config writes needed)
+#   2. Installs a pre-push hook in the cht-core working copy (if mounted)
+#   3. Verifies every sandbox layer; exits non-zero if a critical layer is down
+#
+# The independent layers (any one is sufficient; all should be active):
+#   L1  no write credentials, no Docker socket (image + compose)
+#   L2  system git pushInsteadOf -> error://, push.default=nothing (image)
+#   L3  nothing to authenticate a push with (no tokens/keys in env or fs)
+#   L4  pre-push hook + dummy identity (this script)
+#   L5  agent instructions (~/.claude/CLAUDE.md + settings.json deny rules)
+
+set -uo pipefail
+
+CHT_CORE_PATH="${CHT_CORE_PATH:-/workspace/cht-core}"
+FAILURES=0
+
+ok()   { echo "  [OK]   $1"; }
+warn() { echo "  [WARN] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+
+echo "[cht-agent] Initializing git/credential sandbox..."
+
+# 1. Dummy identity via environment — overrides any config without write
+# access, and persists for `docker exec` sessions through bashrc.
+export GIT_AUTHOR_NAME="CHT Agent"
+export GIT_AUTHOR_EMAIL="agent@cht-agent.local"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+
+if ! grep -q "GIT_AUTHOR_NAME" /home/agent/.bashrc 2>/dev/null; then
+  cat >> /home/agent/.bashrc << 'EOF'
+export GIT_AUTHOR_NAME="CHT Agent"
+export GIT_AUTHOR_EMAIL="agent@cht-agent.local"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+EOF
+fi
+
+# 2. Pre-push hook in the working copy (defense in depth — push is already
+# blocked at the system git config and there is nothing to authenticate with).
+if git -C "$CHT_CORE_PATH" rev-parse --git-dir > /dev/null 2>&1; then
+  HOOKS_DIR="$(git -C "$CHT_CORE_PATH" rev-parse --absolute-git-dir)/hooks"
+  mkdir -p "$HOOKS_DIR" 2>/dev/null || true
+  cat > "$HOOKS_DIR/pre-push" 2>/dev/null << 'HOOK'
+#!/bin/bash
+echo "========================================"
+echo "  BLOCKED: the cht-agent cannot push."
+echo "  All work stays on local branches."
+echo "  The host user reviews and pushes."
+echo "========================================"
+exit 1
+HOOK
+  # set -e is intentionally off; if .git/hooks is owned by another uid the
+  # write fails silently, so verify and warn rather than assume L4 is up.
+  if [ -f "$HOOKS_DIR/pre-push" ] && chmod +x "$HOOKS_DIR/pre-push" 2>/dev/null; then
+    ok "pre-push hook installed in working copy"
+  else
+    warn "could not install pre-push hook (working copy .git owned by another uid?) — L4 degraded; push still blocked by L2/L3"
+  fi
+else
+  # Cloning in here is impossible by design: the hardened .git/config shadow
+  # mount requires the .git directory to exist before the container starts.
+  warn "cht-core working copy not found at $CHT_CORE_PATH — run docker/scripts/bootstrap-workspace.sh on the HOST, then restart"
+fi
+
+echo "[cht-agent] Sandbox verification:"
+
+# L2: system-level push block. Check each scheme explicitly — pushInsteadOf is
+# multi-valued, so a "some value exists" check would miss a clobbered https
+# rewrite (which is the scheme the agent's clones actually use).
+SYS_REWRITES="$(git config --system --get-all url.error://push-blocked-by-policy.pushInsteadOf 2>/dev/null)"
+for scheme in "https://github.com/" "git@github.com:" "ssh://git@github.com/"; do
+  if printf '%s\n' "$SYS_REWRITES" | grep -qxF "$scheme"; then
+    ok "system pushInsteadOf rewrites $scheme push URLs to error://"
+  else
+    fail "system pushInsteadOf is missing the $scheme rewrite"
+  fi
+done
+if [ "$(git config --system push.default 2>/dev/null)" = "nothing" ]; then
+  ok "push.default=nothing"
+else
+  fail "push.default is not 'nothing'"
+fi
+
+# L1/L3: no way to authenticate a write
+if command -v ssh > /dev/null 2>&1; then
+  fail "ssh binary present"
+else
+  ok "no ssh binary"
+fi
+if ls /home/agent/.ssh/id_* > /dev/null 2>&1; then
+  fail "SSH keys found in /home/agent/.ssh"
+else
+  ok "no SSH keys"
+fi
+TOKENS_FOUND=0
+for tok in GH_TOKEN GITHUB_TOKEN GITHUB_ACCESS_TOKEN GH_ENTERPRISE_TOKEN \
+           GIT_TOKEN GITLAB_TOKEN CR_PAT GIT_ASKPASS GIT_USERNAME GIT_PASSWORD; do
+  if [ -n "${!tok:-}" ]; then
+    fail "$tok is set in the environment"
+    TOKENS_FOUND=1
+  fi
+done
+for credfile in "$HOME/.netrc" "$HOME/.git-credentials"; do
+  if [ -e "$credfile" ]; then
+    fail "credential file present: $credfile"
+    TOKENS_FOUND=1
+  fi
+done
+[ "$TOKENS_FOUND" -eq 0 ] && ok "no git write tokens or credential files (env + ~/.netrc + ~/.git-credentials)"
+if [ "$(git config --system credential.helper 2>/dev/null)" = "" ]; then
+  ok "no credential helper"
+else
+  fail "a credential helper is configured"
+fi
+
+# L1: no Docker access (the agent never runs Docker; bring-up is human-gated)
+if [ -S /var/run/docker.sock ]; then
+  fail "Docker socket is mounted — this grants host-root; remove it"
+else
+  ok "no Docker socket"
+fi
+if command -v docker > /dev/null 2>&1; then
+  fail "docker binary present"
+else
+  ok "no docker binary"
+fi
+
+# Working-copy hardening (compose shadows .git/config read-only)
+if [ -e "$CHT_CORE_PATH/.git/config" ]; then
+  if [ -w "$CHT_CORE_PATH/.git/config" ]; then
+    warn ".git/config is writable — mount the hardened config read-only (see compose)"
+  else
+    ok "working copy .git/config is read-only"
+  fi
+fi
+
+# Read path stays open: cht-conf present for the Test Environment Layer
+if command -v cht > /dev/null 2>&1; then
+  ok "cht-conf available ($(cht --version 2>/dev/null | head -1))"
+else
+  fail "cht-conf (cht binary) not found"
+fi
+
+echo "  identity = $GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "[cht-agent] Sandbox verification FAILED ($FAILURES check(s)). Refusing to start."
+  exit 1
+fi
+echo "[cht-agent] Sandbox verified. Remote read OK, push impossible, no Docker."

--- a/docker/scripts/init-agent-git.sh
+++ b/docker/scripts/init-agent-git.sh
@@ -22,9 +22,10 @@ set -uo pipefail
 
 CHT_CORE_PATH="${CHT_CORE_PATH:-/workspace/cht-core}"
 FAILURES=0
+WARNINGS=0
 
 ok()   { local msg="$1"; echo "  [OK]   $msg"; return 0; }
-warn() { local msg="$1"; echo "  [WARN] $msg"; return 0; }
+warn() { local msg="$1"; echo "  [WARN] $msg"; WARNINGS=$((WARNINGS + 1)); return 0; }
 fail() { local msg="$1"; echo "  [FAIL] $msg"; FAILURES=$((FAILURES + 1)); return 0; }
 
 echo "[cht-agent] Initializing git/credential sandbox..."
@@ -97,10 +98,13 @@ if command -v ssh > /dev/null 2>&1; then
 else
   ok "no ssh binary"
 fi
-if ls /home/agent/.ssh/id_* > /dev/null 2>&1; then
-  fail "SSH keys found in /home/agent/.ssh"
+# Any file other than the disabled-config stub we baked in is unexpected (a
+# private key, known_hosts, etc.) — broader than just the id_* glob.
+SSH_EXTRA="$(ls -A /home/agent/.ssh 2>/dev/null | grep -vx config)"
+if [[ -n "$SSH_EXTRA" ]]; then
+  fail "unexpected files in /home/agent/.ssh: $(echo "$SSH_EXTRA" | tr '\n' ' ')"
 else
-  ok "no SSH keys"
+  ok "no SSH keys (~/.ssh holds only the disabled-config stub)"
 fi
 TOKENS_FOUND=0
 for tok in GH_TOKEN GITHUB_TOKEN GITHUB_ACCESS_TOKEN GH_ENTERPRISE_TOKEN \
@@ -157,4 +161,8 @@ if [[ "$FAILURES" -gt 0 ]]; then
   echo "[cht-agent] Sandbox verification FAILED ($FAILURES check(s)). Refusing to start."
   exit 1
 fi
-echo "[cht-agent] Sandbox verified. Remote read OK, push impossible, no Docker."
+if [[ "$WARNINGS" -gt 0 ]]; then
+  echo "[cht-agent] Sandbox PARTIALLY verified: $WARNINGS warning(s) above — a defense-in-depth layer is degraded (e.g. the pre-push hook or read-only .git/config), but no critical check failed. Remote read OK, push impossible, no Docker."
+else
+  echo "[cht-agent] Sandbox verified. Remote read OK, push impossible, no Docker."
+fi

--- a/docs/docker-agent-runbook.md
+++ b/docs/docker-agent-runbook.md
@@ -1,0 +1,177 @@
+# Operator Runbook — Dockerized cht-agent
+
+Issue: [#114](https://github.com/medic/cht-agent/issues/114) · Design: [`designs/layer_recommendations/test-environment-layer.md`](https://github.com/medic/cht-agent/blob/main/designs/layer_recommendations/test-environment-layer.md)
+
+The cht-agent runs inside a sandboxed container on the shared `cht-agent-net`
+Docker network. It can read public git remotes, edit the mounted cht-core
+working copy, and drive `cht-conf` over HTTP — but it can never push, reach
+the host, or run Docker. **You (the host operator) are the control plane**:
+you bring CHT up and down, approve gated phases, and own every push.
+
+## Security model — what actually contains the agent
+
+Be honest about the threat model before trusting this sandbox with an
+autonomous or untrusted agent:
+
+- **The real push-block is credential absence.** The agent runs arbitrary code
+  (`node -e`, `npm`, `python3`) and controls its own environment, so the
+  `pushInsteadOf` rewrites, the read-only `.git/config` shadow, the pre-push
+  hook, and the `settings.json` deny-list are **accident-prevention** layers,
+  not a wall — a determined or prompt-injected agent can bypass each one
+  (`GIT_CONFIG_SYSTEM=/dev/null`, `git push --no-verify`, `cp` the repo
+  elsewhere, push to a non-GitHub host). What it cannot do is authenticate a
+  push, because no git write credential exists in the container.
+- **Anything mounted or passed as a credential is readable and exfiltratable.**
+  The agent can `cat` the mounted `.credentials.json` and read `ANTHROPIC_API_KEY`,
+  and it has outbound HTTPS via `curl`. **Use a disposable, narrowly-scoped API
+  key — never your personal Claude OAuth credentials.** Treat whatever you mount
+  here as compromised the moment an untrusted ticket runs.
+- **Recommended hardening for untrusted runs (not yet implemented):** restrict
+  the container's outbound network to the CHT instance + a read-only git/npm
+  proxy, so push and credential-exfil are blocked at the network layer rather
+  than relying on credential absence alone. Tracked as a follow-up.
+
+## Division of labour
+
+| Agent (in container) | You (host) |
+|---|---|
+| local branches + commits in the working copy | all `git push` / PRs |
+| Research → Development → QA pipeline | phase approvals (checkpoints) |
+| `cht-conf` over HTTP, CouchDB-tier reset | `npm run local-images`, `docker compose up/down` |
+| polls `/api/v2/monitoring` for readiness | attaches CHT to `cht-agent-net` |
+
+## 1. Bootstrap the workspace (host)
+
+```bash
+# Clones cht-core if absent (full clone — worktrees are rejected), fast-forwards
+# main, creates cht-agent-net, and prints the compose command to run next.
+docker/scripts/bootstrap-workspace.sh ~/src/cht-core
+```
+
+This must run on the host, before the container starts: the compose file
+shadow-mounts the hardened `.git/config` read-only, which requires the
+working copy's `.git` directory to already exist — so the container can never
+clone for itself. Re-running is safe (idempotent).
+
+If your model credentials file doesn't exist yet, create it (or point
+`CLAUDE_CREDENTIALS` at the right path / set `ANTHROPIC_API_KEY` instead):
+
+```bash
+touch ~/.claude/.credentials.json
+```
+
+## 2. Build and start the agent
+
+From the cht-agent repo root:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... CHT_CORE_PATH=$HOME/src/cht-core \
+  docker compose -f docker/docker-compose.cht-agent.yml up -d --build
+```
+
+The key is passed into the container's environment at start, so the
+`docker exec` pipeline runs (step 3) pick it up without re-passing it.
+
+The entrypoint runs `init-agent-git.sh`, which verifies every sandbox layer
+and **refuses to start** if one is missing. Check it:
+
+```bash
+docker logs cht-agent
+```
+
+Expected: `[OK]` for the system push block, no ssh, no tokens, no Docker
+socket/binary, cht-conf present — ending in `Sandbox verified.`
+
+### Verify the sandbox by hand (acceptance checks)
+
+```bash
+docker exec -it cht-agent bash
+
+# read is allowed (public clone/fetch)
+git clone --depth 1 https://github.com/medic/cht-agent.git /tmp/probe
+
+# push is blocked even from a fresh clone (no pre-push hook there — this tests
+# the system pushInsteadOf layer). MUST fail with: "remote-error is not a git
+# command", NOT a username prompt.
+cd /tmp/probe && git commit --allow-empty -m probe && git push origin HEAD
+
+# local branch + commit on the working copy succeed
+cd /workspace/cht-core
+git checkout -b cht-agent/sandbox-probe
+git commit --allow-empty -m "sandbox probe"
+
+# push from the working copy is also blocked (pre-push hook banner + error://)
+git push origin HEAD   # MUST fail
+
+# no docker, no ssh
+docker ps              # MUST fail: command not found
+ssh -V                 # MUST fail: command not found
+```
+
+## 3. Run the pipeline
+
+Run the Research Supervisor against a sample ticket (uses the
+`ANTHROPIC_API_KEY` passed at start):
+
+```bash
+docker exec -it cht-agent bash -lc 'cd /app && npm run research -- tickets/simple-example.md'
+```
+
+Expect the research output for the ticket (no push, no Docker — purely the
+in-container pipeline). Swap in any file under `tickets/` or a path you mount.
+
+(Development and QA supervisor CLIs land in later issues; the container is the
+place they'll run.)
+
+## 4. Human-gated CHT bring-up
+
+When the Test Environment Layer (#66) requests an environment, the agent
+*waits and polls* — you bring it up:
+
+```bash
+# Build images from the agent's edited working copy (Model A rebuild-on-change)
+cd ~/src/cht-core && npm run local-images
+
+# Start the stack, attaching nginx to cht-agent-net via the #66 override
+docker compose -f <cht-core compose files> \
+  -f <cht-agent repo>/docker/cht-agent-net.override.yml up -d
+```
+
+> The override file `docker/cht-agent-net.override.yml` ships with #66.
+> Validate service/network names against your generated compose before
+> relying on it (see the comments in that file).
+
+The agent detects readiness via `GET https://nginx/api/v2/monitoring` and
+continues. CouchDB-tier resets it does itself over HTTP; container restarts
+and rebuilds come back to you.
+
+## 5. Review and push (host only)
+
+When the pipeline finishes (HUMAN CHECKPOINT #2):
+
+```bash
+cd ~/src/cht-core
+git log --oneline main..cht-agent/<ticket>   # review the agent's local branch
+git diff main...cht-agent/<ticket>
+# satisfied? you push from the host — the container never can
+git push origin cht-agent/<ticket>
+```
+
+## 6. Teardown
+
+```bash
+docker compose -f docker/docker-compose.cht-agent.yml down
+# CHT stack: docker compose -f <cht-core compose files> down -v
+# Full cleanup of the shared network (only once nothing else uses it):
+docker network rm cht-agent-net
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| compose fails mounting `git-config.hardened` over `.git/config` | working copy is a git worktree (`.git` is a file) or missing. Run `docker/scripts/bootstrap-workspace.sh` on the host. |
+| `Sandbox verification FAILED` in `docker logs` | a hardening layer is missing — read which `[FAIL]` fired; don't bypass it. |
+| working-copy files unwritable from container | host uid ≠ 1000. Rebuild with a matching uid or chown the copy. |
+| agent can't reach `https://nginx` | CHT stack not attached to `cht-agent-net` — re-run compose with the #66 override; `docker network inspect cht-agent-net` should list nginx. |
+| `fetch` fails for an `ssh://` or `git@` URL | by design (no ssh binary). Use the `https://` URL. |


### PR DESCRIPTION
Closes #114.

Containerizes the cht-agent so the pipeline runs inside an isolated sandbox on
the shared `cht-agent-net` network. The agent can read public git remotes and
edit a mounted cht-core working copy, but cannot push, reach host credentials,
or run Docker — the host operator owns all pushes and all CHT/Docker bring-up.

### Scope (maps to the issue)
- **Operator runbook** `docs/docker-agent-runbook.md` — bootstrap → build →
  verify → run → human-gated CHT bring-up → review/push → teardown, plus a
  Security Model section.
- **Image** `docker/Dockerfile` — `node:22-bookworm`, cht-conf baked in,
  multi-layer git/push/credential hardening, non-root `agent` user (`ARG AGENT_UID`),
  code-gen tooling extension point, HEALTHCHECK.
- **Compose** `docker/docker-compose.cht-agent.yml` — external `cht-agent-net`,
  RO `.credentials.json` mount, RO shadow of the working copy `.git/config`,
  `restart: "no"`, `no-new-privileges` + `cap_drop: ALL`, resource limits, no
  Docker socket.
- **Sandbox scripts** `docker/scripts/{agent-entrypoint,init-agent-git,bootstrap-workspace}.sh`
  — startup verification that refuses to start if a layer is down, host-side
  workspace bootstrap, dummy git identity, pre-push hook.
- **Agent config** `docker/agent/{CLAUDE.md,settings.json}` — sandbox rules +
  allow/deny permissions.

### Acceptance criteria
Follow the operator runbook through step 3:
- [ ] Image builds and the container comes up; `docker logs cht-agent` ends in `Sandbox verified.`
- [ ] Sandbox security probes pass (runbook §2 "Verify by hand"): public clone/fetch works;
      `git push` from both a fresh `/tmp` clone **and** the working copy hard-fails with
      `remote-error is not a git command` (no username prompt); `docker ps` and `ssh -V`
      → command not found; no socket, no credentials.
- [ ] Research sample ticket runs end-to-end using your `ANTHROPIC_API_KEY`:
      ```
      ANTHROPIC_API_KEY=sk-ant-... CHT_CORE_PATH=$HOME/src/cht-core \
        docker compose -f docker/docker-compose.cht-agent.yml up -d --build
      docker exec -it cht-agent bash -lc 'cd /app && npm run research -- tickets/simple-example.md'
      ```
      → produces research output for the ticket.
- [ ] `cht --version` resolves in the image (cht-conf available for the Test Environment Layer).

### Security model (see runbook)
The config/hook/deny layers are accident-prevention; the real push-block is
credential absence. Use a scoped, disposable model key (never personal OAuth).
Network-egress restriction for fully-untrusted runs is tracked as a follow-up (#<egress-issue>).

### Dependency
Builds independently. The end-to-end CHT-on-network path also needs
`docker/cht-agent-net.override.yml`, which ships with #66.