### PR TITLE
feat(#8): wire test-generation layer into Development Supervisor

### DIFF
--- a/src/agents/code-generation-agent.ts
+++ b/src/agents/code-generation-agent.ts
@@ -781,7 +781,25 @@ export class CodeGenerationAgent {
    * Validate generated files
    */
   private validateGeneratedFiles(files: GeneratedFile[]): GeneratedFile[] {
-    return files.filter(file => this.normalizeGeneratedFile(file));
+    return files
+      .filter(file => this.normalizeGeneratedFile(file))
+      .filter(file => this.keepNonTestFile(file));
+  }
+
+  /**
+   * F-D: test-gen owns test authorship in all modes (matches the prompt policy).
+   * The CLI code-gen module can author `*.spec.*`/`*.test.*` via its native tools;
+   * drop those so the test-gen phase is the single author (and there is no
+   * same-path collision with test-gen's output). Anchored to the extension so it
+   * never catches `manifest.js` / `latest.js` / `contest/...` (unlike a substring
+   * check on "test"/"spec").
+   */
+  private keepNonTestFile(file: GeneratedFile): boolean {
+    if (/\.(spec|test)\.[cm]?[jt]sx?$/.test(file.relativePath)) {
+      console.log(`[Code Gen Agent] Dropping code-gen-authored test file (test-gen owns tests): ${file.relativePath}`);
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/agents/test-generation-agent.ts
+++ b/src/agents/test-generation-agent.ts
@@ -1,0 +1,218 @@
+import {
+  IssueTemplate,
+  OrchestrationPlan,
+  ResearchFindings,
+  CodeGenerationResult,
+  GeneratedFile,
+  FileLanguage,
+  TestGenerationResult,
+} from '../types';
+import { TestGenModuleInput, TestType } from '../layers/test-gen/interface';
+import {
+  ContextFile,
+  GeneratedFile as LayerGeneratedFile,
+} from '../layers/code-gen/interface';
+import { TestGenModuleRegistry, createDefaultTestGenRegistry } from '../layers/test-gen/registry';
+import { LLMProvider, createLLMProviderFromEnv } from '../llm';
+import { readFromChtCore, listChtCoreDirectory } from '../utils/staging';
+import {
+  snapshotChtCore,
+  rollbackChtCore,
+  ChtCoreSnapshot,
+  RollbackResult,
+} from '../layers/code-gen/modules/claude-code-cli/workspace';
+
+/**
+ * Focused agent-level input for building a TestGenModuleInput. Carries only what
+ * the Development Supervisor has on hand once code generation has completed.
+ */
+export interface TestGenerationInput {
+  issue: IssueTemplate;
+  researchFindings: ResearchFindings;
+  orchestrationPlan: OrchestrationPlan;
+  /** Generated source files; their `.files` become the layer's `generatedCode`. */
+  codeGeneration: CodeGenerationResult;
+  chtCorePath: string;
+  /** Test types to request. Defaults to `['unit']` when omitted. */
+  testTypes?: TestType[];
+  /** Feedback from a previous iteration, surfaced as an external context file. */
+  additionalContext?: string;
+}
+
+/**
+ * Convert the agent-level input into a TestGenModuleInput for the test-gen layer.
+ *
+ * Mirrors code-generation-agent's `buildModuleInput`. Pure aside from the
+ * `readFile`/`listDirectory` closures it binds (they read from cht-core on
+ * demand). `codeGeneration.files` is the types-local GeneratedFile[], which is
+ * exactly what `TestGenModuleInput.generatedCode` expects, so it passes through
+ * unchanged. The `TestGenerationAgent` below calls this to build the module input.
+ */
+export function buildTestGenModuleInput(input: TestGenerationInput): TestGenModuleInput {
+  const contextFiles: ContextFile[] = [];
+  if (input.additionalContext) {
+    contextFiles.push({
+      path: 'feedback/additional-context.md',
+      content: input.additionalContext,
+      source: 'external',
+    });
+  }
+
+  return {
+    ticket: input.issue,
+    researchFindings: input.researchFindings,
+    orchestrationPlan: input.orchestrationPlan,
+    generatedCode: input.codeGeneration.files,
+    contextFiles,
+    testTypes: input.testTypes ?? ['unit'],
+    targetDirectory: input.chtCorePath,
+    readFile: (filePath: string) => readFromChtCore(filePath, input.chtCorePath),
+    listDirectory: (dirPath: string) => listChtCoreDirectory(dirPath, input.chtCorePath),
+  };
+}
+
+const LANGUAGE_BY_EXTENSION: Record<string, FileLanguage> = {
+  ts: 'typescript',
+  js: 'javascript',
+  json: 'json',
+  xml: 'xml',
+  yml: 'yaml',
+  yaml: 'yaml',
+  properties: 'properties',
+  md: 'markdown',
+  html: 'html',
+  css: 'css',
+  sh: 'shell',
+};
+
+/**
+ * Infer a FileLanguage from a path extension. Mirrors code-generation-agent's
+ * `inferLanguage`; duplicated rather than shared to keep the agents decoupled.
+ */
+function inferLanguageFromPath(filePath: string): FileLanguage {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return LANGUAGE_BY_EXTENSION[ext || ''] || 'typescript';
+}
+
+/**
+ * Convert the layer's GeneratedFile[] (`path`/`content`/`purpose`) to the
+ * types-local GeneratedFile[]. Test files are always new, so `type` is forced
+ * to `'test'` and `action` to `'create'`; `language` is inferred from the path.
+ */
+function convertModuleFiles(files: LayerGeneratedFile[]): GeneratedFile[] {
+  return files.map(file => ({
+    relativePath: file.path,
+    content: file.content,
+    language: inferLanguageFromPath(file.path),
+    type: 'test' as const,
+    description: file.purpose ?? '',
+    action: 'create' as const,
+  }));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Inspect a RollbackResult and decide throw-vs-warn, mirroring code-gen's
+ * handleRollbackOutcome. A failed `reset` means cht-core could not be returned
+ * to its pre-run HEAD (a dangerous state), so it throws; the test-gen node's
+ * non-fatal wrapper then surfaces it without crashing the run. clean/stashPop
+ * failures warn but do not throw.
+ */
+export function handleTestGenRollbackOutcome(rollback: RollbackResult): void {
+  const anyFailed =
+    rollback.reset === 'failed' ||
+    rollback.clean === 'failed' ||
+    rollback.stashPop === 'failed';
+  if (!anyFailed) return;
+
+  console.error('[Test Gen Agent] ROLLBACK INCOMPLETE; cht-core may be in an unexpected state:');
+  for (const e of rollback.errors) console.error(`[Test Gen Agent]   - ${e}`);
+
+  if (rollback.reset === 'failed') {
+    throw new Error(
+      `test-gen rollback failed: ${rollback.errors.join('; ')}. ` +
+      'Inspect the cht-core working tree before retrying.',
+    );
+  }
+}
+
+/** Options for constructing a {@link TestGenerationAgent}. */
+export interface TestGenerationAgentOptions {
+  llmProvider?: LLMProvider;
+  testGenRegistry?: TestGenModuleRegistry;
+}
+
+/**
+ * Agent wrapping the test-gen layer registry. Mirrors CodeGenerationAgent:
+ * builds a TestGenModuleInput from the focused TestGenerationInput, runs the
+ * active module, and converts its output to a types-local TestGenerationResult.
+ */
+export class TestGenerationAgent {
+  private readonly llm: LLMProvider;
+  private readonly registry: TestGenModuleRegistry;
+
+  constructor(options: TestGenerationAgentOptions = {}) {
+    this.llm = options.llmProvider || createLLMProviderFromEnv();
+    this.registry = options.testGenRegistry || createDefaultTestGenRegistry(this.llm);
+  }
+
+  async generate(input: TestGenerationInput): Promise<TestGenerationResult> {
+    // Containment (iter8 Fix 2a): a provider that does not honor custom tools
+    // (the claude-cli provider) runs its own agentic loop and can write into the
+    // cht-core tree outside staging/HC2. Snapshot before generation and roll back
+    // any out-of-band write afterward. A provider that honors custom tools runs
+    // in-process and never writes to the tree, so it is not wrapped.
+    if (this.llm.honorsCustomTools) {
+      return this.runGeneration(input);
+    }
+    return this.runContainedGeneration(input);
+  }
+
+  private async runGeneration(input: TestGenerationInput): Promise<TestGenerationResult> {
+    const moduleInput = buildTestGenModuleInput(input);
+    const out = await this.registry.getActiveModule().generate(moduleInput);
+    return {
+      files: convertModuleFiles(out.files),
+      explanation: out.explanation,
+      requirementsChecklist: out.requirementsChecklist,
+      warnings: out.warnings,
+      tokensUsed: out.tokensUsed,
+      modelUsed: out.modelUsed,
+    };
+  }
+
+  private async runContainedGeneration(input: TestGenerationInput): Promise<TestGenerationResult> {
+    let snapshot: ChtCoreSnapshot;
+    try {
+      snapshot = await snapshotChtCore(input.chtCorePath);
+    } catch (error) {
+      // chtCorePath is not a usable git working tree (or git failed). The
+      // non-fatal contract governs test-gen: log and proceed without
+      // containment rather than abort the run.
+      console.warn(
+        `[Test Gen Agent] Snapshot failed; proceeding without containment: ${errorMessage(error)}`,
+      );
+      return this.runGeneration(input);
+    }
+
+    // Capture the work outcome first so rollback runs even if generation threw,
+    // and so legitimate in-memory output is never reverted.
+    let result: TestGenerationResult | undefined;
+    let workError: unknown;
+    try {
+      result = await this.runGeneration(input);
+    } catch (error) {
+      workError = error;
+    }
+
+    // Explicit try/catch via the captured outcome (not finally): rollback runs
+    // after capture, and a rollback failure surfaces without masking a work error.
+    handleTestGenRollbackOutcome(await rollbackChtCore(input.chtCorePath, snapshot));
+
+    if (workError) throw workError;
+    return result as TestGenerationResult;
+  }
+}

--- a/src/agents/test-generation-agent.ts
+++ b/src/agents/test-generation-agent.ts
@@ -194,15 +194,26 @@ export class TestGenerationAgent {
     const examples: Array<{ path: string; content: string }> = [];
     for (const dir of dirs) {
       if (examples.length >= 3) break;
-      const entries = await listChtCoreDirectory(dir, input.chtCorePath);
-      const specs = entries.filter(e => /\.(spec|test)\.\w+$/.test(e));
-      for (const spec of specs) {
-        if (examples.length >= 3) break;
-        const content = await readFromChtCore(spec, input.chtCorePath);
-        if (content) examples.push({ path: spec, content });
-      }
+      examples.push(...await this.collectSpecsFromDir(dir, input.chtCorePath, 3 - examples.length));
     }
-    return examples;
+    return examples.slice(0, 3);
+  }
+
+  /** Up to `limit` readable `*.spec.*`/`*.test.*` files in `dir`; [] on any miss (never throws). */
+  private async collectSpecsFromDir(
+    dir: string,
+    chtCorePath: string,
+    limit: number,
+  ): Promise<Array<{ path: string; content: string }>> {
+    const entries = await listChtCoreDirectory(dir, chtCorePath);
+    const specs = entries.filter(e => /\.(spec|test)\.\w+$/.test(e));
+    const found: Array<{ path: string; content: string }> = [];
+    for (const spec of specs) {
+      if (found.length >= limit) break;
+      const content = await readFromChtCore(spec, chtCorePath);
+      if (content) found.push({ path: spec, content });
+    }
+    return found;
   }
 
   private async runGeneration(input: TestGenerationInput): Promise<TestGenerationResult> {

--- a/src/agents/test-generation-agent.ts
+++ b/src/agents/test-generation-agent.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import {
   IssueTemplate,
   OrchestrationPlan,
@@ -35,8 +36,13 @@ export interface TestGenerationInput {
   chtCorePath: string;
   /** Test types to request. Defaults to `['unit']` when omitted. */
   testTypes?: TestType[];
-  /** Feedback from a previous iteration, surfaced as an external context file. */
+  /** Feedback from a previous iteration, threaded into the plan prompt. */
   additionalContext?: string;
+  /**
+   * Nearby existing `*.spec.*`/`*.test.*` files used as a style anchor. Populated
+   * by {@link TestGenerationAgent.generate} when absent; a caller may pre-seed it.
+   */
+  existingTestExamples?: Array<{ path: string; content: string }>;
 }
 
 /**
@@ -49,14 +55,10 @@ export interface TestGenerationInput {
  * unchanged. The `TestGenerationAgent` below calls this to build the module input.
  */
 export function buildTestGenModuleInput(input: TestGenerationInput): TestGenModuleInput {
+  // No test-gen module reads contextFiles, so routing additionalContext there was
+  // dead (M6). Forward it (and the style-anchor examples) on the fields the module
+  // actually reads: `additionalContext` (plan prompt) and `existingTestExamples`.
   const contextFiles: ContextFile[] = [];
-  if (input.additionalContext) {
-    contextFiles.push({
-      path: 'feedback/additional-context.md',
-      content: input.additionalContext,
-      source: 'external',
-    });
-  }
 
   return {
     ticket: input.issue,
@@ -66,6 +68,8 @@ export function buildTestGenModuleInput(input: TestGenerationInput): TestGenModu
     contextFiles,
     testTypes: input.testTypes ?? ['unit'],
     targetDirectory: input.chtCorePath,
+    additionalContext: input.additionalContext,
+    existingTestExamples: input.existingTestExamples,
     readFile: (filePath: string) => readFromChtCore(filePath, input.chtCorePath),
     listDirectory: (dirPath: string) => listChtCoreDirectory(dirPath, input.chtCorePath),
   };
@@ -160,15 +164,45 @@ export class TestGenerationAgent {
   }
 
   async generate(input: TestGenerationInput): Promise<TestGenerationResult> {
+    // Populate the style-anchor examples (M6) unless the caller pre-seeded them.
+    // Reads only (no tree mutation), so it is safe before the containment snapshot.
+    const enriched: TestGenerationInput = {
+      ...input,
+      existingTestExamples: input.existingTestExamples ?? await this.gatherExistingTestExamples(input),
+    };
+
     // Containment (iter8 Fix 2a): a provider that does not honor custom tools
     // (the claude-cli provider) runs its own agentic loop and can write into the
     // cht-core tree outside staging/HC2. Snapshot before generation and roll back
     // any out-of-band write afterward. A provider that honors custom tools runs
     // in-process and never writes to the tree, so it is not wrapped.
     if (this.llm.honorsCustomTools) {
-      return this.runGeneration(input);
+      return this.runGeneration(enriched);
     }
-    return this.runContainedGeneration(input);
+    return this.runContainedGeneration(enriched);
+  }
+
+  /**
+   * Glob up to 3 nearby existing `*.spec.*`/`*.test.*` files (in the directories
+   * of the generated source) to anchor the generated tests' style (M6). Reads via
+   * the staging helpers, which return [] / null on any miss, so this never throws.
+   */
+  private async gatherExistingTestExamples(
+    input: TestGenerationInput,
+  ): Promise<Array<{ path: string; content: string }>> {
+    const dirs = new Set(input.codeGeneration.files.map(f => path.dirname(f.relativePath)));
+    const examples: Array<{ path: string; content: string }> = [];
+    for (const dir of dirs) {
+      if (examples.length >= 3) break;
+      const entries = await listChtCoreDirectory(dir, input.chtCorePath);
+      const specs = entries.filter(e => /\.(spec|test)\.\w+$/.test(e));
+      for (const spec of specs) {
+        if (examples.length >= 3) break;
+        const content = await readFromChtCore(spec, input.chtCorePath);
+        if (content) examples.push({ path: spec, content });
+      }
+    }
+    return examples;
   }
 
   private async runGeneration(input: TestGenerationInput): Promise<TestGenerationResult> {

--- a/src/layers/code-gen/lib/output-parsing.ts
+++ b/src/layers/code-gen/lib/output-parsing.ts
@@ -225,3 +225,105 @@ export function parseSingleFileContent(rawOutput: string): string {
   // resulting file passes eol-last lint and behaves correctly under `git diff`.
   return trimmed.length > 0 ? trimmed + '\n' : trimmed;
 }
+
+/**
+ * Strip a leading opening-fence line (```lang) and a trailing lone ``` line,
+ * anchored to the FIRST/LAST line only — never global-strips backticks, which
+ * would corrupt an interior template literal. Line-anchored (promoted from the
+ * test-gen continuation assembler); safe for the first-gen parser.
+ */
+export function stripDanglingFences(content: string): string {
+  const lines = content.split('\n');
+  if (lines.length > 0 && /^```[\w-]*\s*$/.test(lines[0])) lines.shift();
+  if (lines.length > 0 && /^```\s*$/.test(lines[lines.length - 1])) lines.pop();
+  return lines.join('\n');
+}
+
+/**
+ * Extract the first fenced code block even when wrapped in preamble/prose, via a
+ * LINEAR line scan (NOT a lazy `[\s\S]*?` regex — that is the Sonar S8786
+ * quadratic hazard on a never-closing/truncated fence). Returns the inner content,
+ * or null when there is no wrapping fence. A missing closing fence (truncated CLI
+ * output) yields everything after the opening fence. Interior fences (real code
+ * before the fence) are left alone.
+ */
+function extractFencedBlock(content: string): string | null {
+  const lines = content.split('\n');
+  const openIdx = lines.findIndex(l => /^```[\w-]*$/.test(l.trim()));
+  // No fence, or only a trailing dangling fence (let stripDanglingFences handle it).
+  if (openIdx < 0 || openIdx === lines.length - 1) return null;
+  // A fence preceded by real code is an interior fence (e.g. a markdown string in
+  // the test body), not a wrapper — do not slice it out.
+  const codeBeforeFence = lines.slice(0, openIdx).some(l => {
+    const t = l.trimStart();
+    return t.length > 0 && CODE_START_PATTERNS.some(p => p.test(t));
+  });
+  if (codeBeforeFence) return null;
+  let closeIdx = -1;
+  for (let i = lines.length - 1; i > openIdx; i--) {
+    if (/^```$/.test(lines[i].trim())) { closeIdx = i; break; }
+  }
+  const inner = closeIdx > openIdx ? lines.slice(openIdx + 1, closeIdx) : lines.slice(openIdx + 1);
+  return inner.join('\n');
+}
+
+// Leading-preamble shapes the CLI adds that the narrow PROSE_PATTERN misses.
+const FIRST_GEN_PREAMBLE_PATTERNS: RegExp[] = [
+  PROSE_PATTERN,                                            // "Here is...", "The following..."
+  /^#{1,6}\s/,                                              // markdown heading
+  /^[-*+]\s/,                                               // bullet list
+  /^\d+[.)]\s/,                                             // numbered list
+  /^I\b/,                                                   // "I'll"/"I've"/"I will" (apostrophe defeats PROSE_PATTERN)
+  /^(here|let|sure|okay|ok|now|below|following|looking|based)\b/i, // lowercase conversational openers
+];
+
+/**
+ * First-gen preamble strip: like stripReasoningPreamble but with broader leading-
+ * prose detection. Still guarded by CODE_KEYWORD_PATTERN (a real code line is never
+ * treated as prose) and still requires a subsequent code-start line to strip, so it
+ * only ever removes leading natural-language lines.
+ */
+function stripFirstGenPreamble(content: string): string {
+  const lines = content.split('\n');
+  const firstNonEmpty = lines.findIndex(l => l.trim().length > 0);
+  if (firstNonEmpty < 0) return content;
+  const firstLine = lines[firstNonEmpty].trimStart();
+  const looksLikePreamble =
+    FIRST_GEN_PREAMBLE_PATTERNS.some(p => p.test(firstLine)) && !CODE_KEYWORD_PATTERN.test(firstLine);
+  if (!looksLikePreamble) return content;
+  const codeStartIdx = lines.findIndex((line, idx) => {
+    if (idx <= firstNonEmpty) return false;
+    const trimmedLine = line.trimStart();
+    if (trimmedLine.length === 0) return false;
+    return CODE_START_PATTERNS.some(p => p.test(trimmedLine));
+  });
+  if (codeStartIdx > 0) {
+    console.log(`[Code Gen Lib]   Stripped ${codeStartIdx} line(s) of LLM preamble (first-gen)`);
+    return lines.slice(codeStartIdx).join('\n');
+  }
+  return content;
+}
+
+/**
+ * Hardened FIRST-GENERATION single-file parser for CLI output that can carry a
+ * leading preamble, a markdown fence, and/or trailing prose (which the anchored
+ * parseSingleFileContent misses). MUST NOT be used on continuation chunks: the
+ * broadened preamble strip would eat a mid-construct resumed line (M3a). Those keep
+ * parseSingleFileContent (code-gen continuation) / parseContinuationChunk (test-gen).
+ */
+export function parseFirstGenFileContent(rawOutput: string): string {
+  let content = rawOutput.trim();
+
+  const fenced = extractFencedBlock(content);
+  if (fenced !== null) content = fenced;
+
+  const fileMatch = /^=== FILE:.*===\n(?:PURPOSE:.*\n)?--- CONTENT START ---\n([\s\S]*?)\n--- CONTENT END ---/
+    .exec(content);
+  if (fileMatch) content = fileMatch[1];
+
+  content = stripFirstGenPreamble(content);
+  content = stripDanglingFences(content);
+
+  const trimmed = content.trim();
+  return trimmed.length > 0 ? trimmed + '\n' : trimmed;
+}

--- a/src/layers/code-gen/lib/output-parsing.ts
+++ b/src/layers/code-gen/lib/output-parsing.ts
@@ -239,6 +239,14 @@ export function stripDanglingFences(content: string): string {
   return lines.join('\n');
 }
 
+/** Index of the first line after `from` whose trimmed form matches `re`, or -1. Linear. */
+function firstMatchAfter(lines: string[], from: number, re: RegExp): number {
+  for (let i = from + 1; i < lines.length; i++) {
+    if (re.test(lines[i].trim())) return i;
+  }
+  return -1;
+}
+
 /**
  * Extract the first fenced code block even when wrapped in preamble/prose, via a
  * LINEAR line scan (NOT a lazy `[\s\S]*?` regex — that is the Sonar S8786
@@ -259,10 +267,14 @@ function extractFencedBlock(content: string): string | null {
     return t.length > 0 && CODE_START_PATTERNS.some(p => p.test(t));
   });
   if (codeBeforeFence) return null;
-  let closeIdx = -1;
-  for (let i = lines.length - 1; i > openIdx; i--) {
-    if (/^```$/.test(lines[i].trim())) { closeIdx = i; break; }
-  }
+  // The wrapper close is the FIRST bare ``` after the open (MG-2) — not the last,
+  // so a trailing fenced note or a second block is not swallowed. If there is no
+  // bare close, fall back to the first LANGUAGE-TAGGED close (NEW-1: ```js); this
+  // stays dormant whenever a bare close exists, so it never mis-slices a nested
+  // tagged opener in the body. If neither exists (truncated output), take
+  // everything after the open (unchanged).
+  let closeIdx = firstMatchAfter(lines, openIdx, /^```\s*$/);
+  if (closeIdx < 0) closeIdx = firstMatchAfter(lines, openIdx, /^```[\w-]+\s*$/);
   const inner = closeIdx > openIdx ? lines.slice(openIdx + 1, closeIdx) : lines.slice(openIdx + 1);
   return inner.join('\n');
 }

--- a/src/layers/code-gen/lib/output-parsing.ts
+++ b/src/layers/code-gen/lib/output-parsing.ts
@@ -316,6 +316,66 @@ function stripFirstGenPreamble(content: string): string {
   return content;
 }
 
+// Trailing code punctuation or a backtick — a strong signal the line is code, not prose.
+const CODE_SIGNAL_PUNCT = /[)}\];`]/;
+
+/**
+ * True when a trimmed line carries a code signal: a code keyword / code-start
+ * pattern, or code punctuation `)` `}` `;` `]` / a backtick. Used to STOP the
+ * trailing-prose strip at the first real code line (scanning from the end).
+ */
+function hasCodeSignal(trimmed: string): boolean {
+  return (
+    CODE_KEYWORD_PATTERN.test(trimmed) ||
+    CODE_START_PATTERNS.some(p => p.test(trimmed)) ||
+    CODE_SIGNAL_PUNCT.test(trimmed)
+  );
+}
+
+/**
+ * Per-line flag: is line `i` inside an OPEN template literal? Odd backtick parity
+ * counted from the top of the file (a line is "inside" when an odd number of
+ * backticks precede it). Linear single pass. Lines inside a template literal are
+ * never stripped as trailing prose — they may be legitimate multi-line content.
+ */
+function insideOpenTemplate(lines: string[]): boolean[] {
+  const inside: boolean[] = new Array(lines.length);
+  let backticks = 0;
+  for (let i = 0; i < lines.length; i++) {
+    inside[i] = backticks % 2 === 1;
+    for (const ch of lines[i]) if (ch === '`') backticks++;
+  }
+  return inside;
+}
+
+/**
+ * Strip TRAILING natural-language prose on the unfenced first-gen path (MG-1),
+ * symmetric to the leading-preamble strip. Scans from the end, skipping blank
+ * lines, and removes a trailing line ONLY when it looks like a capitalized prose
+ * sentence (PROSE_PATTERN) AND carries no code signal AND is not inside a template
+ * literal. Stops at the first line (from the end) with a code signal, so it never
+ * eats trailing code (`});`, `);`, `module.exports = {...};`), comments, or
+ * multi-line template-literal content. Trailing-only by design (interior prose is
+ * NEW-3, deferred). Linear line scan (no S8786 hazard).
+ */
+function stripTrailingProse(content: string): string {
+  const lines = content.split('\n');
+  const inside = insideOpenTemplate(lines);
+  let cut = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length === 0) { cut = i; continue; }
+    if (PROSE_PATTERN.test(trimmed) && !hasCodeSignal(trimmed) && !inside[i]) { cut = i; continue; }
+    break;
+  }
+  // cut === 0 means every line looked like prose: this is trailing-prose stripping,
+  // not whole-file deletion, so leave an all-prose response untouched (it fails the
+  // looksLikeCode gate as before rather than becoming empty).
+  if (cut === 0 || cut >= lines.length) return content;
+  console.log(`[Code Gen Lib]   Stripped ${lines.length - cut} trailing prose line(s) (first-gen)`);
+  return lines.slice(0, cut).join('\n');
+}
+
 /**
  * Hardened FIRST-GENERATION single-file parser for CLI output that can carry a
  * leading preamble, a markdown fence, and/or trailing prose (which the anchored
@@ -334,6 +394,7 @@ export function parseFirstGenFileContent(rawOutput: string): string {
   if (fileMatch) content = fileMatch[1];
 
   content = stripFirstGenPreamble(content);
+  content = stripTrailingProse(content);
   content = stripDanglingFences(content);
 
   const trimmed = content.trim();

--- a/src/layers/code-gen/lib/output-parsing.ts
+++ b/src/layers/code-gen/lib/output-parsing.ts
@@ -239,6 +239,12 @@ export function stripDanglingFences(content: string): string {
   return lines.join('\n');
 }
 
+// A top-level member-expression (or plain) assignment, e.g. `messages.intro = ...`.
+// CODE_START_PATTERNS does not model this shape, so without it a first line that
+// assigns a fence-containing template literal is mistaken for a wrapper (MG-3, a
+// SILENT content-loss class: the truncated output still passes `node --check`).
+const MEMBER_ASSIGN_RE = /^\w+(?:\.\w+)*\s*=/;
+
 /** Index of the first line after `from` whose trimmed form matches `re`, or -1. Linear. */
 function firstMatchAfter(lines: string[], from: number, re: RegExp): number {
   for (let i = from + 1; i < lines.length; i++) {
@@ -264,7 +270,7 @@ function extractFencedBlock(content: string): string | null {
   // the test body), not a wrapper — do not slice it out.
   const codeBeforeFence = lines.slice(0, openIdx).some(l => {
     const t = l.trimStart();
-    return t.length > 0 && CODE_START_PATTERNS.some(p => p.test(t));
+    return t.length > 0 && (CODE_START_PATTERNS.some(p => p.test(t)) || MEMBER_ASSIGN_RE.test(t));
   });
   if (codeBeforeFence) return null;
   // The wrapper close is the FIRST bare ``` after the open (MG-2) — not the last,

--- a/src/layers/code-gen/lib/output-parsing.ts
+++ b/src/layers/code-gen/lib/output-parsing.ts
@@ -235,7 +235,8 @@ export function parseSingleFileContent(rawOutput: string): string {
 export function stripDanglingFences(content: string): string {
   const lines = content.split('\n');
   if (lines.length > 0 && /^```[\w-]*\s*$/.test(lines[0])) lines.shift();
-  if (lines.length > 0 && /^```\s*$/.test(lines[lines.length - 1])) lines.pop();
+  const last = lines.at(-1);
+  if (last !== undefined && /^```\s*$/.test(last)) lines.pop();
   return lines.join('\n');
 }
 
@@ -349,7 +350,7 @@ function insideOpenTemplate(lines: string[]): boolean[] {
   let backticks = 0;
   for (let i = 0; i < lines.length; i++) {
     inside[i] = backticks % 2 === 1;
-    for (const ch of lines[i]) if (ch === '`') backticks++;
+    backticks += (lines[i].match(/`/g) ?? []).length;
   }
   return inside;
 }
@@ -364,16 +365,28 @@ function insideOpenTemplate(lines: string[]): boolean[] {
  * multi-line template-literal content. Trailing-only by design (interior prose is
  * NEW-3, deferred). Linear line scan (no S8786 hazard).
  */
-function stripTrailingProse(content: string): string {
-  const lines = content.split('\n');
-  const inside = insideOpenTemplate(lines);
+/**
+ * A trailing line is strippable when it is blank, or a capitalized prose sentence
+ * carrying no code signal that is not inside an open template literal.
+ */
+function shouldStripTrailingLine(trimmed: string, insideTpl: boolean): boolean {
+  if (trimmed.length === 0) return true;
+  return PROSE_PATTERN.test(trimmed) && !hasCodeSignal(trimmed) && !insideTpl;
+}
+
+/** Index of the first line to drop scanning from the end, or lines.length if none. */
+function trailingProseCutIndex(lines: string[], inside: boolean[]): number {
   let cut = lines.length;
   for (let i = lines.length - 1; i >= 0; i--) {
-    const trimmed = lines[i].trim();
-    if (trimmed.length === 0) { cut = i; continue; }
-    if (PROSE_PATTERN.test(trimmed) && !hasCodeSignal(trimmed) && !inside[i]) { cut = i; continue; }
-    break;
+    if (!shouldStripTrailingLine(lines[i].trim(), inside[i])) break;
+    cut = i;
   }
+  return cut;
+}
+
+function stripTrailingProse(content: string): string {
+  const lines = content.split('\n');
+  const cut = trailingProseCutIndex(lines, insideOpenTemplate(lines));
   // cut === 0 means every line looked like prose: this is trailing-prose stripping,
   // not whole-file deletion, so leave an all-prose response untouched (it fails the
   // looksLikeCode gate as before rather than becoming empty).

--- a/src/layers/code-gen/modules/claude-api/index.ts
+++ b/src/layers/code-gen/modules/claude-api/index.ts
@@ -27,6 +27,7 @@ import {
 } from '../../lib/file-manifest';
 import {
   parseSingleFileContent as libParseSingleFileContent,
+  parseFirstGenFileContent as libParseFirstGenFileContent,
   looksLikeCodeContent as libLooksLikeCodeContent,
   looksLikePythonScript as libLooksLikePythonScript,
   extractPythonScript as libExtractPythonScript,
@@ -664,7 +665,10 @@ export class ClaudeApiCodeGenModule implements CodeGenModule {
     if (!response) return { file: null, tokensUsed: 0, truncated: false };
     const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
     const truncated = response.stopReason === 'max_tokens';
-    const rawContent = this.parseSingleFileContent(response.content);
+    // First-gen parse: hardened for CLI preamble/fence/prose (F-B). The
+    // continuation path keeps this.parseSingleFileContent (byte-identical) to
+    // avoid eating a mid-construct resumed line.
+    const rawContent = libParseFirstGenFileContent(response.content);
 
     if (!this.isUsableContent(rawContent, planItem.filePath, response.content.length)) {
       return { file: null, tokensUsed, truncated: false };

--- a/src/layers/test-gen/index.ts
+++ b/src/layers/test-gen/index.ts
@@ -1,0 +1,3 @@
+export * from './interface';
+export * from './registry';
+export * from './schemas';

--- a/src/layers/test-gen/interface.ts
+++ b/src/layers/test-gen/interface.ts
@@ -1,0 +1,46 @@
+import { IssueTemplate, OrchestrationPlan, ResearchFindings, GeneratedFile } from '../../types';
+import { ContextFile, GeneratedFile as LayerGeneratedFile } from '../code-gen/interface';
+
+export type TestType = 'unit' | 'integration' | 'e2e';
+
+export interface TestScenario {
+  requirement: string;
+  scenarios: Array<{
+    name: string;
+    type: 'happy-path' | 'error' | 'edge-case' | 'boundary';
+    description: string;
+  }>;
+}
+
+export interface TestGenModuleInput {
+  ticket: IssueTemplate;
+  researchFindings: ResearchFindings;
+  orchestrationPlan: OrchestrationPlan;
+  generatedCode: GeneratedFile[];
+  contextFiles: ContextFile[];
+  testTypes: TestType[];
+  targetDirectory: string;
+  readFile?: (path: string) => Promise<string | null>;
+  listDirectory?: (dirPath: string) => Promise<string[]>;
+  directoryListing?: string;
+  /** Existing test patterns from the target codebase for style matching */
+  existingTestExamples?: Array<{ path: string; content: string }>;
+  /** Feedback from a previous iteration for refinement */
+  additionalContext?: string;
+}
+
+export interface TestGenModuleOutput {
+  files: LayerGeneratedFile[];
+  explanation: string;
+  tokensUsed?: number;
+  modelUsed?: string;
+  requirementsChecklist: TestScenario[];
+  warnings?: string[];
+}
+
+export interface TestGenModule {
+  name: string;
+  version: string;
+  generate(input: TestGenModuleInput): Promise<TestGenModuleOutput>;
+  validate?(): Promise<boolean>;
+}

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -1,0 +1,1063 @@
+import {
+  TestGenModule,
+  TestGenModuleInput,
+  TestGenModuleOutput,
+  TestScenario,
+  TestType,
+} from '../../interface';
+import { GeneratedFile } from '../../../code-gen/interface';
+import {
+  LLMProvider,
+  LLMToolDefinition,
+  ToolHandler,
+  createLLMProviderFromEnv,
+} from '../../../../llm';
+import { readEnv } from '../../../../utils/env';
+import { isShutdownRequested } from '../../../../utils/shutdown';
+import {
+  TestPlanSchema,
+  TestContentAssertions,
+  RequirementsChecklistSchema,
+} from '../../schemas';
+import {
+  parseSingleFileContent as libParseSingleFileContent,
+  looksLikeCodeContent as libLooksLikeCodeContent,
+} from '../../../code-gen/lib/output-parsing';
+import { sanitizePath } from '../../../code-gen/lib/plan';
+
+export const TEST_PLAN_START = '=== TEST PLAN ===';
+export const TEST_PLAN_END = '=== END TEST PLAN ===';
+const TEST_PLAN_ITEM_RE = /^\d+\.\s*(unit|integration|e2e)\s+(\S+)\s+(?:->|→)\s+(\S+)\s*[-–—]\s*(.+)/i;
+
+export interface TestPlanItem {
+  filePath: string;
+  testType: TestType;
+  targetSourceFile: string;
+  description: string;
+}
+
+const READ_FILE_TOOL: LLMToolDefinition = {
+  name: 'read_file',
+  description:
+    'Read the contents of a source file under test or a test pattern file ' +
+    'from the CHT-Core workspace. Use this to inspect implementations, ' +
+    'interfaces, or existing test fixtures before generating a test file.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Relative path within the CHT-Core workspace (e.g. "api/src/controllers/contacts.js")',
+      },
+    },
+    required: ['path'],
+  },
+};
+
+const LIST_DIRECTORY_TOOL: LLMToolDefinition = {
+  name: 'list_directory',
+  description:
+    'List files and subdirectories within the CHT-Core workspace. ' +
+    'Use this to discover existing test files, fixtures, or source files ' +
+    'related to the code under test.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Relative path to a directory (e.g. "api/tests/mocha/")',
+      },
+    },
+    required: ['path'],
+  },
+};
+
+function buildToolHandler(input: TestGenModuleInput): ToolHandler {
+  return async (toolName, toolInput) => {
+    const filePath = toolInput.path as string;
+    if (toolName === 'read_file') return handleReadFileTool(input, filePath);
+    if (toolName === 'list_directory') return handleListDirectoryTool(input, filePath);
+    return `Error: Unknown tool: ${toolName}`;
+  };
+}
+
+async function handleReadFileTool(input: TestGenModuleInput, filePath: string): Promise<string> {
+  if (!input.readFile) return 'Error: read_file is not available';
+  const content = await input.readFile(filePath);
+  return content ?? `Error: File not found: ${filePath}`;
+}
+
+async function handleListDirectoryTool(input: TestGenModuleInput, filePath: string): Promise<string> {
+  if (!input.listDirectory) return 'Error: list_directory is not available';
+  const entries = await input.listDirectory(filePath);
+  return entries.length > 0 ? entries.join('\n') : `(empty directory: ${filePath})`;
+}
+
+function logContinuationOverBudget(filePath: string, maxContinuations: number): void {
+  console.warn(
+    `[Test Gen Module]   ! File "${filePath}" still truncated after ${maxContinuations} continuation(s). ` +
+    `Consider raising TEST_GEN_MAX_CONTINUATIONS or splitting the file.`
+  );
+}
+
+type RetryAttemptResult =
+  | { outcome: 'success'; file: GeneratedFile; tokensUsed: number }
+  | { outcome: 'retry'; failures: string[]; tokensUsed: number }
+  | { outcome: 'over-budget'; tokensUsed: number };
+
+function decideRetryNext(
+  attempt: RetryAttemptResult,
+): { kind: 'terminate'; file: GeneratedFile | null } | { kind: 'retry'; failures: string[] } {
+  if (attempt.outcome === 'success') return { kind: 'terminate', file: attempt.file };
+  if (attempt.outcome === 'over-budget') return { kind: 'terminate', file: null };
+  return { kind: 'retry', failures: attempt.failures };
+}
+
+export class ClaudeApiTestGenModule implements TestGenModule {
+  name = 'claude-api';
+
+  version = '0.1.0';
+
+  private provider?: LLMProvider;
+
+  /** Per-invocation cache for the TEST_GEN_MAX_CONTINUATIONS env read. Reset at the top of generate(). */
+  private maxContinuationsCache: number | null = null;
+
+  constructor(provider?: LLMProvider) {
+    this.provider = provider;
+  }
+
+  private getProvider(): LLMProvider {
+    this.provider ??= createLLMProviderFromEnv();
+    return this.provider;
+  }
+
+  async generate(input: TestGenModuleInput): Promise<TestGenModuleOutput> {
+    const llm = this.getProvider();
+    this.resetPerInvocationCaches();
+
+    this.logGenerateStart(input);
+
+    const planResult = await this.resolvePlan(input, llm.modelName);
+    if (planResult.bailout) return planResult.bailout;
+    const { plan, planTokens } = planResult;
+
+    this.surfacePlan(plan);
+
+    const genResult = await this.generateTestFilesSequentially(plan, input);
+    const checklistPhase = await this.runChecklistPhase(input, genResult.files);
+    const totalTokens = planTokens + genResult.tokensUsed + checklistPhase.tokensUsed;
+    const checklist = checklistPhase.checklist;
+
+    const warnings = this.validateAgainstManifest(genResult.files, plan);
+    this.logPostCallValidation(warnings);
+    this.logGeneratedFiles(genResult.files);
+
+    const combinedWarnings = [...warnings, ...genResult.warnings];
+
+    return {
+      files: genResult.files,
+      explanation:
+        `Generated ${genResult.files.length} test file(s) for "${input.ticket.issue.title}" ` +
+        `targeting the ${input.ticket.issue.technical_context.domain} domain.`,
+      tokensUsed: totalTokens,
+      modelUsed: llm.modelName,
+      requirementsChecklist: checklist,
+      warnings: combinedWarnings.length > 0 ? combinedWarnings : undefined,
+    };
+  }
+
+  /**
+   * Phase 3: generate the requirements checklist, skipped when no files were
+   * produced (no source to checklist, and it avoids a wasted provider call).
+   * Non-fatal: a checklist error returns an empty checklist rather than failing
+   * the whole generation.
+   */
+  private async runChecklistPhase(
+    input: TestGenModuleInput,
+    files: GeneratedFile[],
+  ): Promise<{ checklist: TestScenario[]; tokensUsed: number }> {
+    if (files.length === 0) {
+      console.log('[Test Gen Module] Skipping requirements checklist (0 test files generated)');
+      return { checklist: [], tokensUsed: 0 };
+    }
+    try {
+      const checklistResult = await this.generateRequirementsChecklist(input, files);
+      return { checklist: checklistResult.checklist, tokensUsed: checklistResult.tokensUsed };
+    } catch (error) {
+      console.error('[Test Gen Module] Requirements checklist generation failed:', error);
+      return { checklist: [], tokensUsed: 0 };
+    }
+  }
+
+  async validate(): Promise<boolean> {
+    if (readEnv('LLM_PROVIDER') === 'claude-cli') return true;
+    return Boolean(readEnv('ANTHROPIC_API_KEY'));
+  }
+
+  private resetPerInvocationCaches(): void {
+    this.maxContinuationsCache = null;
+  }
+
+  private logGenerateStart(input: TestGenModuleInput): void {
+    console.log(`[Test Gen Module] Generating tests for "${input.ticket.issue.title}"...`);
+    console.log(
+      `[Test Gen Module] Source files: ${input.generatedCode.length}, test types: ${input.testTypes.join(', ')}`
+    );
+  }
+
+  /**
+   * Resolve the plan from one of three sources:
+   *  (a) Selective regeneration (failing test files, iteration-3 wiring).
+   *  (b) Plan call (generate via the LLM).
+   *  (c) Empty plan (early-return a bailout result).
+   */
+  private async resolvePlan(
+    input: TestGenModuleInput,
+    modelName: string,
+  ): Promise<{ plan: TestPlanItem[]; planTokens: number; bailout?: never }
+    | { bailout: TestGenModuleOutput; plan: TestPlanItem[]; planTokens: number }> {
+    const failingTestFiles = readFailingTestFiles(input);
+    if (failingTestFiles && failingTestFiles.length > 0) {
+      console.log(
+        `[Test Gen Module] Selective regeneration: reusing plan for ${failingTestFiles.length} failing file(s)`
+      );
+      return { plan: [...failingTestFiles], planTokens: 0 };
+    }
+
+    try {
+      const planResult = await this.generateTestPlan(input);
+      if (planResult.plan.length === 0) {
+        console.log('[Test Gen Module] Empty plan generated — no test files to produce');
+        return {
+          plan: [],
+          planTokens: planResult.tokensUsed,
+          bailout: {
+            files: [],
+            explanation: `No test plan generated for "${input.ticket.issue.title}".`,
+            tokensUsed: planResult.tokensUsed,
+            modelUsed: modelName,
+            requirementsChecklist: [],
+          },
+        };
+      }
+      return { plan: planResult.plan, planTokens: planResult.tokensUsed };
+    } catch (error) {
+      console.error('[Test Gen Module] Plan generation failed:', error);
+      return {
+        plan: [],
+        planTokens: 0,
+        bailout: {
+          files: [],
+          explanation: `Test generation failed for "${input.ticket.issue.title}".`,
+          tokensUsed: 0,
+          modelUsed: modelName,
+          requirementsChecklist: [],
+        },
+      };
+    }
+  }
+
+  private surfacePlan(plan: TestPlanItem[]): void {
+    console.log(`[Test Gen Module] Plan (${plan.length} file(s)):`);
+    for (const item of plan) {
+      console.log(`[Test Gen Module]   ${item.testType} ${item.filePath} -> ${item.targetSourceFile}`);
+    }
+  }
+
+  private logPostCallValidation(warnings: string[]): void {
+    if (warnings.length === 0) return;
+    console.log(`[Test Gen Module] Validation warnings:`);
+    for (const warning of warnings) {
+      console.log(`[Test Gen Module]   ! ${warning}`);
+    }
+  }
+
+  private logGeneratedFiles(files: GeneratedFile[]): void {
+    console.log(`[Test Gen Module] Generated ${files.length} test file(s):`);
+    for (const file of files) {
+      console.log(`[Test Gen Module]   + ${file.path}`);
+    }
+  }
+
+  // ============================================================================
+  // Phase 1: Test Plan Generation
+  // ============================================================================
+
+  private async generateTestPlan(
+    input: TestGenModuleInput,
+  ): Promise<{ plan: TestPlanItem[]; tokensUsed: number }> {
+    const llm = this.getProvider();
+    const prompt = this.buildTestPlanPrompt(input);
+
+    const response = await llm.invoke(prompt, { temperature: 0.3, maxTokens: 8192, disableTools: true });
+    const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
+
+    const plan = this.parseTestPlan(response.content);
+
+    const validation = TestPlanSchema.safeParse({ items: plan });
+    if (!validation.success) {
+      console.log(
+        `[Test Gen Module] Plan validation warnings: ${validation.error.issues.map(i => i.message).join(', ')}`
+      );
+    }
+
+    return { plan, tokensUsed };
+  }
+
+  parseTestPlan(rawContent: string): TestPlanItem[] {
+    const items: TestPlanItem[] = [];
+
+    const planMatch = new RegExp(String.raw`${TEST_PLAN_START}([\s\S]*?)${TEST_PLAN_END}`).exec(rawContent);
+    const content = planMatch ? planMatch[1] : rawContent;
+
+    const lineRegex = new RegExp(TEST_PLAN_ITEM_RE.source, 'gim');
+    let match;
+    while ((match = lineRegex.exec(content)) !== null) {
+      items.push({
+        testType: match[1].toLowerCase() as TestType,
+        filePath: sanitizePath(match[2]),
+        targetSourceFile: sanitizePath(match[3]),
+        description: match[4].trim(),
+      });
+    }
+
+    return items;
+  }
+
+  // ============================================================================
+  // Phase 2: Sequential Test File Generation
+  // ============================================================================
+
+  private async generateTestFilesSequentially(
+    plan: TestPlanItem[],
+    input: TestGenModuleInput,
+  ): Promise<{ files: GeneratedFile[]; tokensUsed: number; warnings: string[] }> {
+    const generatedFiles: GeneratedFile[] = [];
+    let totalTokens = 0;
+    const warnings: string[] = [];
+    const testGenTools = this.buildTestGenTools(input);
+
+    for (let i = 0; i < plan.length; i++) {
+      if (isShutdownRequested()) {
+        console.log(`[Test Gen Module] Shutdown requested; stopping after ${i} of ${plan.length} files`);
+        break;
+      }
+      const planItem = plan[i];
+      console.log(`[Test Gen Module] Generating file ${i + 1}/${plan.length}: ${planItem.filePath}`);
+
+      const result = await this.generateSingleTestFileWithRetry({
+        planItem,
+        fullPlan: plan,
+        input,
+        previouslyGenerated: generatedFiles,
+        testGenTools,
+      });
+
+      totalTokens += result.tokensUsed;
+      this.collectGeneratedFile(result, planItem, generatedFiles, warnings);
+    }
+
+    return { files: generatedFiles, tokensUsed: totalTokens, warnings };
+  }
+
+  private collectGeneratedFile(
+    result: { file: GeneratedFile | null; tokensUsed: number },
+    planItem: TestPlanItem,
+    generatedFiles: GeneratedFile[],
+    warnings: string[],
+  ): void {
+    if (result.file) {
+      generatedFiles.push(result.file);
+      console.log(`[Test Gen Module]   OK ${planItem.filePath} (${result.file.content.length} chars)`);
+    } else {
+      console.log(`[Test Gen Module]   FAILED ${planItem.filePath} (no usable content after retries)`);
+      warnings.push(`Failed to generate ${planItem.filePath} after retries`);
+    }
+  }
+
+  /**
+   * Generate a single test file with assertion-based retry (max 3 attempts).
+   * Handles truncation via continuation calls within each attempt.
+   */
+  private async generateSingleTestFileWithRetry(opts: {
+    planItem: TestPlanItem;
+    fullPlan: TestPlanItem[];
+    input: TestGenModuleInput;
+    previouslyGenerated: GeneratedFile[];
+    testGenTools?: { tools: LLMToolDefinition[]; toolHandler: ToolHandler };
+    maxAttempts?: number;
+  }): Promise<{ file: GeneratedFile | null; tokensUsed: number }> {
+    const maxAttempts = opts.maxAttempts ?? 3;
+    const state = { failures: [] as string[], totalTokens: 0 };
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const decision = await this.executeOneRetryAttempt(opts, attempt, maxAttempts, state);
+      if (decision) return decision;
+    }
+    return { file: null, tokensUsed: state.totalTokens };
+  }
+
+  private async executeOneRetryAttempt(
+    opts: {
+      planItem: TestPlanItem;
+      fullPlan: TestPlanItem[];
+      input: TestGenModuleInput;
+      previouslyGenerated: GeneratedFile[];
+      testGenTools?: { tools: LLMToolDefinition[]; toolHandler: ToolHandler };
+    },
+    attempt: number,
+    maxAttempts: number,
+    state: { failures: string[]; totalTokens: number },
+  ): Promise<{ file: GeneratedFile | null; tokensUsed: number } | null> {
+    if (isShutdownRequested()) {
+      console.log(`[Test Gen Module]   Shutdown requested; aborting retry for ${opts.planItem.filePath}`);
+      return { file: null, tokensUsed: state.totalTokens };
+    }
+    if (attempt > 1) {
+      console.log(`[Test Gen Module]   Retry ${attempt}/${maxAttempts} for ${opts.planItem.filePath}`);
+    }
+    const attemptResult = await this.runSingleFileAttempt({
+      ...opts,
+      previousFailures: state.failures.length > 0 ? state.failures : undefined,
+    });
+    state.totalTokens += attemptResult.tokensUsed;
+    const decision = decideRetryNext(attemptResult);
+    if (decision.kind === 'terminate') return { file: decision.file, tokensUsed: state.totalTokens };
+    state.failures = decision.failures;
+    return null;
+  }
+
+  /**
+   * Run one attempt at generating a single test file. The outcome is one of:
+   *  - 'success'      : assertions passed; return the file to the retry loop.
+   *  - 'retry'        : assertions failed (or LLM returned nothing); the caller
+   *                     should iterate again with the failure reasons.
+   *  - 'over-budget'  : continuation cap reached after truncation; further
+   *                     retries cannot help so the loop must terminate.
+   */
+  private async runSingleFileAttempt(args: {
+    planItem: TestPlanItem;
+    fullPlan: TestPlanItem[];
+    input: TestGenModuleInput;
+    previouslyGenerated: GeneratedFile[];
+    testGenTools?: { tools: LLMToolDefinition[]; toolHandler: ToolHandler };
+    previousFailures?: string[];
+  }): Promise<RetryAttemptResult> {
+    const result = await this.generateSingleTestFile({
+      planItem: args.planItem,
+      fullPlan: args.fullPlan,
+      input: args.input,
+      previouslyGenerated: args.previouslyGenerated,
+      testGenTools: args.testGenTools,
+      previousFailures: args.previousFailures,
+    });
+    let tokensUsed = result.tokensUsed;
+
+    if (!result.file) {
+      return { outcome: 'retry', failures: ['LLM call returned no usable content'], tokensUsed };
+    }
+
+    let file = result.file;
+    if (result.truncated) {
+      const continuation = await this.completeTruncatedFile(file, args.planItem, args.input);
+      tokensUsed += continuation.tokensUsed;
+      if (continuation.overBudget) return { outcome: 'over-budget', tokensUsed };
+      file = continuation.file;
+    }
+
+    const failures = this.assertFileContent(file);
+    if (failures.length === 0) return { outcome: 'success', file, tokensUsed };
+
+    console.log(`[Test Gen Module]   Assertion failures: ${failures.join('; ')}`);
+    return { outcome: 'retry', failures, tokensUsed };
+  }
+
+  /**
+   * Continue a truncated file via continuation calls. Returns the assembled
+   * file, plus a flag indicating whether the continuation cap was reached.
+   */
+  private async completeTruncatedFile(
+    file: GeneratedFile,
+    planItem: TestPlanItem,
+    input: TestGenModuleInput,
+  ): Promise<
+    | { overBudget: true; tokensUsed: number }
+    | { overBudget: false; file: GeneratedFile; tokensUsed: number }
+  > {
+    console.log(`[Test Gen Module]   Output truncated for ${planItem.filePath}, continuing...`);
+    const contResult = await this.continueTruncatedGeneration(file.content, planItem, input);
+    if (contResult.stillTruncated) {
+      console.warn(
+        `[Test Gen Module]   File "${planItem.filePath}" exceeds the continuation budget; not retrying.`
+      );
+      return { overBudget: true, tokensUsed: contResult.tokensUsed };
+    }
+    return {
+      overBudget: false,
+      file: { ...file, content: file.content + contResult.continuation },
+      tokensUsed: contResult.tokensUsed,
+    };
+  }
+
+  /**
+   * Build LLM tool definitions and handler for filesystem access during generation.
+   * Returns undefined when neither readFile nor listDirectory callbacks are available.
+   */
+  private buildTestGenTools(
+    input: TestGenModuleInput,
+  ): { tools: LLMToolDefinition[]; toolHandler: ToolHandler } | undefined {
+    if (!input.readFile && !input.listDirectory) return undefined;
+    const tools: LLMToolDefinition[] = [];
+    if (input.readFile) tools.push(READ_FILE_TOOL);
+    if (input.listDirectory) tools.push(LIST_DIRECTORY_TOOL);
+    const toolHandler = buildToolHandler(input);
+    return { tools, toolHandler };
+  }
+
+  /**
+   * Single LLM call to generate one test file.
+   * Returns the generated file, token usage, and whether output was truncated.
+   */
+  private async generateSingleTestFile(opts: {
+    planItem: TestPlanItem;
+    fullPlan: TestPlanItem[];
+    input: TestGenModuleInput;
+    previouslyGenerated: GeneratedFile[];
+    testGenTools?: { tools: LLMToolDefinition[]; toolHandler: ToolHandler };
+    previousFailures?: string[];
+  }): Promise<{ file: GeneratedFile | null; tokensUsed: number; truncated: boolean }> {
+    const { planItem, fullPlan, input, previouslyGenerated, testGenTools, previousFailures } = opts;
+    const prompt = this.buildSingleTestFilePrompt({
+      planItem,
+      fullPlan,
+      input,
+      previouslyGenerated,
+      previousFailures,
+    });
+    const response = await this.invokeLLM(prompt, testGenTools, planItem.filePath);
+    if (!response) return { file: null, tokensUsed: 0, truncated: false };
+    const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
+    const truncated = response.stopReason === 'max_tokens';
+    const rawContent = this.parseSingleFileContent(response.content);
+
+    if (!this.isUsableContent(rawContent, planItem.filePath, response.content.length)) {
+      return { file: null, tokensUsed, truncated: false };
+    }
+    return {
+      file: { path: planItem.filePath, content: rawContent, purpose: planItem.description },
+      tokensUsed,
+      truncated,
+    };
+  }
+
+  private async invokeLLM(
+    prompt: string,
+    testGenTools: { tools: LLMToolDefinition[]; toolHandler: ToolHandler } | undefined,
+    filePath: string,
+  ): Promise<Awaited<ReturnType<LLMProvider['invoke']>> | null> {
+    try {
+      return await this.getProvider().invoke(prompt, {
+        temperature: 0.3,
+        maxTokens: 65536,
+        // A provider that does not honor custom tools (the claude-cli provider)
+        // ignores them, appends no deny-list, and runs its own agentic loop with
+        // native Write/Edit, writing into the target repo outside staging/HC2.
+        // Force text-only (disableTools) there so the deny-list is applied and
+        // the response is capturable. Keep tools on capable providers (API, A8).
+        ...(testGenTools && this.getProvider().honorsCustomTools
+          ? { tools: testGenTools.tools, toolHandler: testGenTools.toolHandler }
+          : { disableTools: true }),
+      });
+    } catch (error) {
+      console.error(`[Test Gen Module]   Failed to generate ${filePath}:`, error);
+      return null;
+    }
+  }
+
+  private isUsableContent(rawContent: string, filePath: string, rawCharCount: number): boolean {
+    if (!rawContent || rawContent.length < 20) {
+      console.log(`[Test Gen Module]   No usable content for ${filePath} (${rawCharCount} raw chars)`);
+      return false;
+    }
+    if (!this.looksLikeCodeContent(rawContent, filePath)) {
+      console.log(`[Test Gen Module]   Output for ${filePath} appears to be LLM reasoning, not code — skipping`);
+      return false;
+    }
+    return true;
+  }
+
+  // ============================================================================
+  // Truncation Handling
+  // ============================================================================
+
+  private getMaxContinuations(): number {
+    if (this.maxContinuationsCache !== null) return this.maxContinuationsCache;
+    const env = readEnv('TEST_GEN_MAX_CONTINUATIONS');
+    if (!env) {
+      this.maxContinuationsCache = 5;
+      return 5;
+    }
+    const n = Number.parseInt(env, 10);
+    const result = Number.isFinite(n) && n > 0 ? n : 5;
+    this.maxContinuationsCache = result;
+    return result;
+  }
+
+  private async continueTruncatedGeneration(
+    partialContent: string,
+    planItem: TestPlanItem,
+    input: TestGenModuleInput,
+    maxContinuations: number = this.getMaxContinuations(),
+  ): Promise<{ continuation: string; tokensUsed: number; stillTruncated: boolean }> {
+    const acc = { content: '', tokens: 0, stopReason: undefined as string | undefined };
+    await this.runContinuationLoop({ partialContent, planItem, input, maxContinuations, acc });
+    const stillTruncated = acc.stopReason === 'max_tokens';
+    if (stillTruncated) logContinuationOverBudget(planItem.filePath, maxContinuations);
+    return { continuation: acc.content, tokensUsed: acc.tokens, stillTruncated };
+  }
+
+  private async runContinuationLoop(args: {
+    partialContent: string;
+    planItem: TestPlanItem;
+    input: TestGenModuleInput;
+    maxContinuations: number;
+    acc: { content: string; tokens: number; stopReason: string | undefined };
+  }): Promise<void> {
+    const { partialContent, planItem, input, maxContinuations, acc } = args;
+    for (let i = 0; i < maxContinuations; i++) {
+      const ok = await this.runOneContinuation({ partialContent, planItem, input, acc, iteration: i });
+      if (!ok) return;
+      if (acc.stopReason !== 'max_tokens') {
+        console.log(`[Test Gen Module]   Continuation complete after ${i + 1} call(s)`);
+        return;
+      }
+      console.log(`[Test Gen Module]   Continuation ${i + 1} still truncated, continuing...`);
+    }
+  }
+
+  private async runOneContinuation(args: {
+    partialContent: string;
+    planItem: TestPlanItem;
+    input: TestGenModuleInput;
+    acc: { content: string; tokens: number; stopReason: string | undefined };
+    iteration: number;
+  }): Promise<boolean> {
+    const { partialContent, planItem, input, acc, iteration } = args;
+    const lastLines = (partialContent + acc.content).split('\n').slice(-50).join('\n');
+    const prompt = this.buildContinuationPrompt(lastLines, planItem, input);
+    let response;
+    try {
+      response = await this.getProvider().invoke(prompt, {
+        temperature: 0.3,
+        maxTokens: 65536,
+        disableTools: true,
+      });
+    } catch (error) {
+      console.error(`[Test Gen Module]   Continuation call ${iteration + 1} failed:`, error);
+      return false;
+    }
+    acc.tokens += (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
+    const continuation = this.parseSingleFileContent(response.content).replace(/\n$/, '');
+    acc.content += '\n' + continuation;
+    acc.stopReason = response.stopReason;
+    return true;
+  }
+
+  // ============================================================================
+  // Phase 3: Requirements Checklist
+  // ============================================================================
+
+  private async generateRequirementsChecklist(
+    input: TestGenModuleInput,
+    generatedTestFiles: GeneratedFile[],
+  ): Promise<{ checklist: TestScenario[]; tokensUsed: number }> {
+    const llm = this.getProvider();
+    const prompt = this.buildRequirementsChecklistPrompt(input, generatedTestFiles);
+
+    const response = await llm.invoke(prompt, { temperature: 0.2, maxTokens: 8192, disableTools: true });
+    const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
+
+    const checklist = this.parseRequirementsChecklist(response.content);
+
+    return { checklist, tokensUsed };
+  }
+
+  parseRequirementsChecklist(rawContent: string): TestScenario[] {
+    const jsonMatch = /\{[\s\S]*\}/.exec(rawContent);
+    if (!jsonMatch) return [];
+
+    try {
+      const parsed = JSON.parse(jsonMatch[0]);
+      const validation = RequirementsChecklistSchema.safeParse(parsed);
+      if (validation.success) {
+        return validation.data.checklist;
+      }
+      if (parsed.checklist && Array.isArray(parsed.checklist)) {
+        return parsed.checklist;
+      }
+    } catch {
+      // Fall through
+    }
+
+    return [];
+  }
+
+  // ============================================================================
+  // Prompt Builders
+  // ============================================================================
+
+  buildTestPlanPrompt(input: TestGenModuleInput): string {
+    const { ticket, orchestrationPlan, generatedCode, testTypes, existingTestExamples } = input;
+
+    const sourceFileSummary = generatedCode
+      .map(f => `- ${f.relativePath} (${f.type}): ${f.description}`)
+      .join('\n');
+
+    let existingPatterns = '';
+    if (existingTestExamples && existingTestExamples.length > 0) {
+      existingPatterns = `\n## Existing Test Patterns in CHT\n`;
+      for (const example of existingTestExamples.slice(0, 3)) {
+        const truncated = example.content.split('\n').slice(0, 40).join('\n');
+        existingPatterns += `\n--- ${example.path} ---\n${truncated}\n`;
+      }
+    }
+
+    return `You are a CHT (Community Health Toolkit) test engineer. Create a test plan for the implementation below.
+
+## Issue Details
+Title: ${ticket.issue.title}
+Type: ${ticket.issue.type}
+Domain: ${ticket.issue.technical_context.domain}
+
+Requirements:
+${ticket.issue.requirements.map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+Acceptance Criteria:
+${ticket.issue.acceptance_criteria.map((c, i) => `${i + 1}. ${c}`).join('\n')}
+
+## Implementation Plan
+${orchestrationPlan.phases.map((p, i) => `${i + 1}. ${p.name}: ${p.description}`).join('\n')}
+
+## Source Files to Test
+${sourceFileSummary}
+
+## Test Types Requested
+${testTypes.join(', ')}
+
+## CHT Test Conventions
+- Unit tests: Mocha + Chai + Sinon, file naming: *.spec.js or *.spec.ts
+- Always include sinon.restore() in afterEach
+- Integration tests: Rosie factories, CHT contact hierarchy, saveDocs()/createUsers() utilities
+- E2E tests: WebdriverIO + Page Object Model, test-id selectors
+- Test files mirror source structure: api/tests/mocha/ for api, webapp/tests/ for webapp
+${existingPatterns}
+${input.additionalContext ? `\n## Feedback from Previous Iteration\n${input.additionalContext}\n` : ''}
+## Instructions
+List every test file you will create. Each must target a specific source file.
+Only create ${testTypes.join(' and ')} tests as requested.
+
+Use this EXACT format:
+
+${TEST_PLAN_START}
+1. unit tests/unit/controllers/contacts.spec.js -> api/src/controllers/contacts.js - Unit tests for contact search endpoint
+2. integration tests/integration/contacts-search.spec.js -> api/src/controllers/contacts.js - Integration test with CouchDB for search
+${TEST_PLAN_END}
+
+Output ONLY the plan section. Do not generate any test code.`;
+  }
+
+  buildSingleTestFilePrompt(opts: {
+    planItem: TestPlanItem;
+    fullPlan: TestPlanItem[];
+    input: TestGenModuleInput;
+    previouslyGenerated: GeneratedFile[];
+    previousFailures?: string[];
+  }): string {
+    const { planItem, fullPlan, input, previouslyGenerated, previousFailures } = opts;
+    const { ticket } = input;
+
+    const planSummary = fullPlan
+      .map((p, i) => `${i + 1}. ${p.testType} ${p.filePath} -> ${p.targetSourceFile}`)
+      .join('\n');
+    const requirementsList = ticket.issue.requirements.map((r, i) => `${i + 1}. ${r}`).join('\n');
+
+    const sourceContext = this.buildSourceContext(planItem, input);
+    const patternContext = this.buildPatternContext(planItem, input);
+    const previousContext = this.buildPreviousContext(previouslyGenerated);
+    const failureContext = this.buildFailureContext(previousFailures);
+
+    return `You are a CHT (Community Health Toolkit) test engineer. Generate a complete test file.
+
+## Test Plan (full context — you are generating one file from this plan)
+${planSummary}
+
+## Current Task
+Test File: ${planItem.filePath}
+Test Type: ${planItem.testType}
+Target: ${planItem.targetSourceFile}
+Description: ${planItem.description}
+
+## Issue Details
+Title: ${ticket.issue.title}
+Type: ${ticket.issue.type}
+Domain: ${ticket.issue.technical_context.domain}
+
+Requirements:
+${requirementsList}
+${sourceContext}
+${patternContext}
+${previousContext}
+${failureContext}
+
+## CHT Test Conventions for ${planItem.testType} tests
+${this.getTestConventions(planItem.testType)}
+
+## Instructions
+Generate the COMPLETE test file for ${planItem.filePath}.
+- Include all imports, setup/teardown hooks, and test cases
+- Cover happy path, error cases, and edge cases
+- Follow the CHT test conventions above
+- Use descriptive test names that explain the expected behavior
+
+Output ONLY the raw file content. Do NOT wrap in markdown code fences.
+Do NOT include any explanations or commentary.
+NEVER say "I'm unable to" or ask questions. Just output the test code.`;
+  }
+
+  private buildSourceContext(planItem: TestPlanItem, input: TestGenModuleInput): string {
+    const targetFile = input.generatedCode.find(
+      f => f.relativePath === planItem.targetSourceFile ||
+        f.relativePath.endsWith(planItem.targetSourceFile)
+    );
+    if (!targetFile) return '';
+    return `\n## Source Code Under Test (${planItem.targetSourceFile})\n\`\`\`\n${targetFile.content}\n\`\`\``;
+  }
+
+  private buildPatternContext(planItem: TestPlanItem, input: TestGenModuleInput): string {
+    const examples = input.existingTestExamples;
+    if (!examples || examples.length === 0) return '';
+    const relevant = examples.find(
+      e => e.path.includes(planItem.testType) ||
+        (planItem.testType === 'unit' && !e.path.includes('integration') && !e.path.includes('e2e'))
+    ) ?? examples[0];
+    if (!relevant) return '';
+    const truncated = relevant.content.split('\n').slice(0, 50).join('\n');
+    return `\n## Example Test Pattern (follow this style)\n--- ${relevant.path} ---\n\`\`\`\n${truncated}\n\`\`\``;
+  }
+
+  private buildPreviousContext(previouslyGenerated: GeneratedFile[]): string {
+    if (previouslyGenerated.length === 0) return '';
+    let previousContext = '\n## Previously Generated Test Files (for consistency)';
+    for (const prev of previouslyGenerated) {
+      const lines = prev.content.split('\n');
+      const preview = lines.slice(0, 10).join('\n');
+      const moreLinesNote = lines.length > 10 ? `... (${lines.length} lines)` : '';
+      previousContext += `\n### ${prev.path}\n\`\`\`\n${preview}\n${moreLinesNote}\n\`\`\``;
+    }
+    return previousContext;
+  }
+
+  private buildFailureContext(previousFailures?: string[]): string {
+    if (!previousFailures || previousFailures.length === 0) return '';
+    const failureList = previousFailures.map(f => `- ${f}`).join('\n');
+    return `\n## PREVIOUS ATTEMPT FAILED\nYour previous output for this file failed these checks:\n${failureList}\nFix these specific issues. Do not repeat the same mistakes.`;
+  }
+
+  private buildContinuationPrompt(
+    lastLines: string,
+    planItem: TestPlanItem,
+    input: TestGenModuleInput,
+  ): string {
+    const { ticket } = input;
+    return `You were generating the test file "${planItem.filePath}" for the CHT issue "${ticket.issue.title}".
+The previous response was truncated. Continue generating from EXACTLY where the output stopped.
+
+## Last 50 lines of the partial output
+\`\`\`
+${lastLines}
+\`\`\`
+
+## Instructions
+- Resume from the next character after the last shown line.
+- Do NOT repeat content already shown.
+- Do NOT restart from the top of the file.
+- Do NOT add prose, explanations, or markdown code fences.
+- Continue with the same indentation and style.
+- When the test file is complete, simply stop.`;
+  }
+
+  private buildRequirementsChecklistPrompt(
+    input: TestGenModuleInput,
+    generatedTestFiles: GeneratedFile[],
+  ): string {
+    const { ticket } = input;
+
+    const testFileSummary = generatedTestFiles
+      .map(f => {
+        const itBlocks = f.content.match(/it\(['"`](.*?)['"`]/g) || [];
+        const testNames = itBlocks.map(b => b.replace(/it\(['"`]/, '').replace(/['"`]$/, ''));
+        const testList = testNames.map(t => `  - ${t}`).join('\n');
+        return `File: ${f.path}\nTests:\n${testList}`;
+      })
+      .join('\n\n');
+
+    return `You are a CHT test engineer. Map each requirement to the test scenarios that cover it.
+
+## Requirements
+${ticket.issue.requirements.map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+## Acceptance Criteria
+${ticket.issue.acceptance_criteria.map((c, i) => `${i + 1}. ${c}`).join('\n')}
+
+## Generated Test Files
+${testFileSummary}
+
+## Instructions
+For each requirement/acceptance criterion, list the test scenarios that verify it.
+Categorize each scenario as: happy-path, error, edge-case, or boundary.
+Flag any requirements that have NO test coverage.
+
+Respond with this exact JSON format:
+{
+  "checklist": [
+    {
+      "requirement": "The exact requirement text",
+      "scenarios": [
+        {
+          "name": "test name from the generated tests",
+          "type": "happy-path",
+          "description": "How this test verifies the requirement"
+        }
+      ]
+    }
+  ]
+}
+
+Output ONLY the JSON. No explanations.`;
+  }
+
+  // ============================================================================
+  // Output parsing
+  // ============================================================================
+
+  looksLikeCodeContent(content: string, filePath: string): boolean {
+    return libLooksLikeCodeContent(content, filePath);
+  }
+
+  parseSingleFileContent(rawOutput: string): string {
+    return libParseSingleFileContent(rawOutput);
+  }
+
+  /**
+   * Public back-compat extractor for raw LLM output.
+   * Preserves the existing test-gen behavior (markdown-fence strip + first
+   * code-line search) so external callers and the spec at
+   * test/layers/test-gen/claude-api-module.spec.ts continue to pass.
+   * Internally the per-file generation path uses {@link parseSingleFileContent}
+   * (lib helper) for reasoning-preamble protection.
+   */
+  extractCodeContent(rawContent: string): string {
+    let content = rawContent.trim();
+
+    const codeBlockMatch = /^```(?:\w+)?\n([\s\S]*?)\n```$/.exec(content);
+    if (codeBlockMatch) {
+      content = codeBlockMatch[1];
+    }
+
+    const lines = content.split('\n');
+    let codeStartIdx = 0;
+    for (let i = 0; i < Math.min(lines.length, 10); i++) {
+      const line = lines[i].trim();
+      if (
+        line.startsWith('import ') || line.startsWith('const ') ||
+        line.startsWith('require(') || line.startsWith("'use strict'") ||
+        line.startsWith('"use strict"') || line.startsWith('/**') ||
+        line.startsWith('//') || line.startsWith('describe(') ||
+        line.startsWith('module.')
+      ) {
+        codeStartIdx = i;
+        break;
+      }
+    }
+
+    return lines.slice(codeStartIdx).join('\n').trim();
+  }
+
+  // ============================================================================
+  // Validation
+  // ============================================================================
+
+  private assertFileContent(file: GeneratedFile): string[] {
+    return TestContentAssertions.validateTestFile(file.content, file.path);
+  }
+
+  validateAgainstManifest(files: GeneratedFile[], plan: TestPlanItem[]): string[] {
+    if (plan.length === 0) return [];
+    const generatedPaths = new Set(files.map(f => f.path));
+    const plannedPaths = new Set(plan.map(p => p.filePath));
+    return [
+      ...plan
+        .filter(item => !generatedPaths.has(item.filePath))
+        .map(item => `Planned but not generated: ${item.filePath}`),
+      ...files
+        .filter(file => !plannedPaths.has(file.path))
+        .map(file => `Generated but not planned: ${file.path}`),
+    ];
+  }
+
+  // ============================================================================
+  // Conventions
+  // ============================================================================
+
+  private getTestConventions(testType: TestType): string {
+    switch (testType) {
+      case 'unit':
+        return `- Framework: Mocha + Chai + Sinon
+- File naming: *.spec.js or *.spec.ts
+- Use expect() style assertions from chai
+- Stub external dependencies with sinon.stub()
+- Always call sinon.restore() in afterEach()
+- Structure: describe('ModuleName', () => { describe('methodName', () => { it('should ...') }) })
+- Mock CouchDB/PouchDB calls, never hit real databases
+- Import pattern: const { expect } = require('chai'); const sinon = require('sinon');`;
+
+      case 'integration':
+        return `- Framework: Mocha + Chai + Supertest
+- Use Rosie factories for test data (factory.build('contact'), factory.build('report'))
+- Use CHT test utilities: saveDocs(), createUsers(), getDoc()
+- Set up test database state in before() hooks
+- Clean up in after() hooks
+- Test real service interactions, not mocked ones
+- Use actual CouchDB for data verification`;
+
+      case 'e2e':
+        return `- Framework: WebdriverIO + Mocha
+- Use Page Object Model pattern
+- Select elements with data-test-id attributes: $('[data-test-id="submit-btn"]')
+- Use wdio helpers: browser.waitForAngular(), browser.url()
+- Structure tests as user workflows, not individual assertions
+- Include wait conditions for async operations
+- Clean up test data after each test`;
+    }
+  }
+}
+
+/**
+ * Read the optional `failingTestFiles` field off the input via a guarded cast.
+ * The TestGenModuleInput interface does not surface this field today; the
+ * supervisor wiring in a later iteration will plumb it through for selective
+ * regeneration. Until then this returns undefined and the generate() flow
+ * takes the LLM-plan branch.
+ */
+function readFailingTestFiles(
+  input: TestGenModuleInput,
+): ReadonlyArray<TestPlanItem> | undefined {
+  const carrier = input as {
+    failingTestFiles?: ReadonlyArray<TestPlanItem>;
+  };
+  return carrier.failingTestFiles;
+}
+
+export function createClaudeApiTestGenModule(provider?: LLMProvider): ClaudeApiTestGenModule {
+  return new ClaudeApiTestGenModule(provider);
+}

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -166,6 +166,25 @@ function extractFirstJsonObject(text: string): string | null {
   return null;
 }
 
+/**
+ * Insert `.additional[.N]` before the `.spec.`/`.test.` segment (same directory,
+ * basename change only), so an existing spec is never overwritten (F-A):
+ *   api/tests/messaging.spec.js -> api/tests/messaging.additional.spec.js
+ *   (counter 2)                 -> api/tests/messaging.additional.2.spec.js
+ * Falls back to inserting before the final extension for a path without a
+ * recognizable `.spec.`/`.test.` segment.
+ */
+/** Upper bound on `.additional.N` sibling probing (defensive; unreachable in practice). */
+const SIBLING_PATH_CAP = 100;
+
+export function siblingSpecPath(filePath: string, counter?: number): string {
+  const suffix = counter ? `.additional.${counter}` : '.additional';
+  const m = /^(.*)(\.(?:spec|test))(\.[^.]+)$/.exec(filePath);
+  if (m) return `${m[1]}${suffix}${m[2]}${m[3]}`;
+  const ext = path.extname(filePath);
+  return `${filePath.slice(0, filePath.length - ext.length)}${suffix}${ext}`;
+}
+
 export class ClaudeApiTestGenModule implements TestGenModule {
   name = 'claude-api';
 
@@ -194,6 +213,11 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     const planResult = await this.resolvePlan(input, llm.modelName);
     if (planResult.bailout) return planResult.bailout;
     const { plan, planTokens, planWarnings } = planResult;
+
+    // F-A: never overwrite an existing spec. Redirect any plan item whose target
+    // already exists on disk to a new sibling path BEFORE generation/emit, so the
+    // action-blind writer can only ever create. Covers both plan sources.
+    await this.resolveTargetPaths(plan, input);
 
     this.surfacePlan(plan);
 
@@ -322,6 +346,43 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     for (const item of plan) {
       console.log(`[Test Gen Module]   ${item.testType} ${item.filePath} -> ${item.targetSourceFile}`);
     }
+  }
+
+  /**
+   * F-A: redirect any plan item whose canonical spec path already exists on disk
+   * to a NEW `*.additional.spec.*` sibling (same directory), so test-gen can never
+   * overwrite pre-existing coverage. Mutates plan items in place — one filePath
+   * change propagates to the emit site, the previously-generated prompt context,
+   * and validateAgainstManifest (single source of truth). The existence check uses
+   * input.readFile (bound to readFromChtCore over the same chtCorePath the writer
+   * uses), so it agrees with the eventual write.
+   */
+  private async resolveTargetPaths(plan: TestPlanItem[], input: TestGenModuleInput): Promise<void> {
+    if (!input.readFile) return; // no existence check available: keep canonical paths
+    for (const item of plan) {
+      if (!(await this.pathExists(item.filePath, input))) continue;
+      const sibling = await this.nextFreeSiblingPath(item.filePath, input);
+      console.log(`[Test Gen Module] Target spec exists; writing sibling instead: ${item.filePath} -> ${sibling}`);
+      item.filePath = sibling;
+    }
+  }
+
+  private async pathExists(relPath: string, input: TestGenModuleInput): Promise<boolean> {
+    if (!input.readFile) return false;
+    return (await input.readFile(relPath)) !== null;
+  }
+
+  /**
+   * First `.additional[.N]` sibling of filePath that does not already exist.
+   * Bounded (SIBLING_PATH_CAP) so a misbehaving readFile can never spin forever;
+   * hitting the cap is not reachable with a real cht-core tree.
+   */
+  private async nextFreeSiblingPath(filePath: string, input: TestGenModuleInput): Promise<string> {
+    let candidate = siblingSpecPath(filePath);
+    for (let n = 2; n <= SIBLING_PATH_CAP && (await this.pathExists(candidate, input)); n++) {
+      candidate = siblingSpecPath(filePath, n);
+    }
+    return candidate;
   }
 
   private logPostCallValidation(warnings: string[]): void {

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -336,7 +336,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
             requirementsChecklist: [],
             // Warnings only when items were dropped as invalid; a genuinely empty
             // plan (no items at all) stays a warning-free intentional no-op so the
-            // supervisor does not mark the todo failed.
+            // supervisor does not mark the TodoTracker entry failed.
             warnings: undefinedIfEmpty(planResult.warnings),
           },
         };

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -560,16 +560,23 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     | { overBudget: false; file: GeneratedFile; tokensUsed: number }
   > {
     console.log(`[Test Gen Module]   Output truncated for ${planItem.filePath}, continuing...`);
-    const contResult = await this.continueTruncatedGeneration(file.content, planItem, input);
-    if (contResult.stillTruncated) {
+    // A truncated first response can carry an unclosed opening ```lang fence that
+    // parseSingleFileContent could not strip (no balanced close in one chunk).
+    // Drop it before continuing so the fence line does not land mid-file (M3c).
+    const base = this.stripDanglingFences(file.content);
+    const contResult = await this.continueTruncatedGeneration(base, planItem, input);
+    if (contResult.stillTruncated || contResult.failed) {
+      const cause = contResult.failed ? 'a continuation call failed' : 'the continuation budget';
       console.warn(
-        `[Test Gen Module]   File "${planItem.filePath}" exceeds the continuation budget; not retrying.`
+        `[Test Gen Module]   File "${planItem.filePath}" not completed (${cause}); not retrying.`
       );
       return { overBudget: true, tokensUsed: contResult.tokensUsed };
     }
     return {
       overBudget: false,
-      file: { ...file, content: file.content + contResult.continuation },
+      // Sanitize the ASSEMBLED content for a trailing lone ``` the continuation
+      // emitted to close the fence we stripped above (M3c).
+      file: { ...file, content: this.stripDanglingFences(base + contResult.continuation) },
       tokensUsed: contResult.tokensUsed,
     };
   }
@@ -683,12 +690,12 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     planItem: TestPlanItem,
     input: TestGenModuleInput,
     maxContinuations: number = this.getMaxContinuations(),
-  ): Promise<{ continuation: string; tokensUsed: number; stillTruncated: boolean }> {
-    const acc = { content: '', tokens: 0, stopReason: undefined as string | undefined };
+  ): Promise<{ continuation: string; tokensUsed: number; stillTruncated: boolean; failed: boolean }> {
+    const acc = { content: '', tokens: 0, stopReason: undefined as string | undefined, failed: false };
     await this.runContinuationLoop({ partialContent, planItem, input, maxContinuations, acc });
     const stillTruncated = acc.stopReason === 'max_tokens';
     if (stillTruncated) logContinuationOverBudget(planItem.filePath, maxContinuations);
-    return { continuation: acc.content, tokensUsed: acc.tokens, stillTruncated };
+    return { continuation: acc.content, tokensUsed: acc.tokens, stillTruncated, failed: acc.failed };
   }
 
   private async runContinuationLoop(args: {
@@ -696,7 +703,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     planItem: TestPlanItem;
     input: TestGenModuleInput;
     maxContinuations: number;
-    acc: { content: string; tokens: number; stopReason: string | undefined };
+    acc: { content: string; tokens: number; stopReason: string | undefined; failed: boolean };
   }): Promise<void> {
     const { partialContent, planItem, input, maxContinuations, acc } = args;
     for (let i = 0; i < maxContinuations; i++) {
@@ -714,7 +721,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     partialContent: string;
     planItem: TestPlanItem;
     input: TestGenModuleInput;
-    acc: { content: string; tokens: number; stopReason: string | undefined };
+    acc: { content: string; tokens: number; stopReason: string | undefined; failed: boolean };
     iteration: number;
   }): Promise<boolean> {
     const { partialContent, planItem, input, acc, iteration } = args;
@@ -728,11 +735,16 @@ export class ClaudeApiTestGenModule implements TestGenModule {
         disableTools: true,
       });
     } catch (error) {
+      // A failed continuation is NOT a completed file: flag it so the caller
+      // terminates over-budget (file dropped) instead of accepting the original
+      // truncated content as a success (M3b). No content is appended here.
       console.error(`[Test Gen Module]   Continuation call ${iteration + 1} failed:`, error);
+      acc.failed = true;
       return false;
     }
     acc.tokens += (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
-    const continuation = this.parseSingleFileContent(response.content).replace(/\n$/, '');
+    // Continuation-only parse: no preamble strip (would eat a real resumed line, M3a).
+    const continuation = this.parseContinuationChunk(response.content);
     acc.content += '\n' + continuation;
     acc.stopReason = response.stopReason;
     return true;
@@ -1020,6 +1032,36 @@ Output ONLY the JSON. No explanations.`;
 
   parseSingleFileContent(rawOutput: string): string {
     return libParseSingleFileContent(rawOutput);
+  }
+
+  /**
+   * Parse a CONTINUATION chunk. Like parseSingleFileContent it strips a balanced
+   * code fence and the `=== FILE: ===` delimiter, but it does NOT run
+   * stripReasoningPreamble: a continuation legitimately resumes mid-string or
+   * mid-comment, and the preamble heuristic would eat that real first line (M3a).
+   */
+  private parseContinuationChunk(rawOutput: string): string {
+    let content = rawOutput.trim();
+    const codeBlockMatch = /^```(?:\w+)?\n([\s\S]*?)\n```$/.exec(content);
+    if (codeBlockMatch) content = codeBlockMatch[1];
+    const fileMatch = /^=== FILE:.*===\n(?:PURPOSE:.*\n)?--- CONTENT START ---\n([\s\S]*?)\n--- CONTENT END ---/
+      .exec(content);
+    if (fileMatch) content = fileMatch[1];
+    return content.trim();
+  }
+
+  /**
+   * Strip a dangling markdown fence left by a truncated/continued response: a
+   * leading opening-fence line (```lang) that never got a balanced close in one
+   * chunk, and a trailing lone ``` a continuation emitted to close it. Anchored
+   * to the first/last line only — never global-strips backticks, which would
+   * corrupt a template literal in the test body (M3c).
+   */
+  private stripDanglingFences(content: string): string {
+    const lines = content.split('\n');
+    if (lines.length > 0 && /^```[\w-]*\s*$/.test(lines[0])) lines.shift();
+    if (lines.length > 0 && /^```\s*$/.test(lines[lines.length - 1])) lines.pop();
+    return lines.join('\n');
   }
 
   /**

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -21,7 +21,7 @@ import {
   RequirementsChecklistSchema,
 } from '../../schemas';
 import {
-  parseSingleFileContent as libParseSingleFileContent,
+  parseFirstGenFileContent as libParseFirstGenFileContent,
   looksLikeCodeContent as libLooksLikeCodeContent,
 } from '../../../code-gen/lib/output-parsing';
 import { sanitizePath } from '../../../code-gen/lib/plan';
@@ -681,7 +681,9 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     if (!response) return { file: null, tokensUsed: 0, truncated: false };
     const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
     const truncated = response.stopReason === 'max_tokens';
-    const rawContent = this.parseSingleFileContent(response.content);
+    // First-gen parse: hardened for CLI preamble/fence/prose (F-B). Continuation
+    // chunks keep parseContinuationChunk (no preamble strip, M3a).
+    const rawContent = libParseFirstGenFileContent(response.content);
 
     if (!this.isUsableContent(rawContent, planItem.filePath, response.content.length)) {
       return { file: null, tokensUsed, truncated: false };
@@ -1089,10 +1091,6 @@ Output ONLY the JSON. No explanations.`;
 
   looksLikeCodeContent(content: string, filePath: string): boolean {
     return libLooksLikeCodeContent(content, filePath);
-  }
-
-  parseSingleFileContent(rawOutput: string): string {
-    return libParseSingleFileContent(rawOutput);
   }
 
   /**

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import {
   TestGenModule,
   TestGenModuleInput,
@@ -72,11 +73,31 @@ const LIST_DIRECTORY_TOOL: LLMToolDefinition = {
   },
 };
 
+/**
+ * Reason a tool path is unsafe to read/list, or null if safe. `toolInput.path`
+ * is untrusted LLM tool-use input that reaches readFile/listDirectory pre-HC2,
+ * so reject a non-string, an absolute path, or any path that escapes the
+ * workspace via a `..` segment (checked after normalization, not a substring).
+ * The handler must resolve to a string, so the caller returns this as an error.
+ */
+function rejectUnsafePath(p: unknown): string | null {
+  if (typeof p !== 'string') return 'Error: tool "path" must be a string';
+  if (path.isAbsolute(p)) return `Error: absolute paths are not allowed: ${p}`;
+  const segments = path.normalize(p).split(/[/\\]/);
+  if (segments.includes('..')) return `Error: path escapes the workspace: ${p}`;
+  return null;
+}
+
 function buildToolHandler(input: TestGenModuleInput): ToolHandler {
   return async (toolName, toolInput) => {
-    const filePath = toolInput.path as string;
-    if (toolName === 'read_file') return handleReadFileTool(input, filePath);
-    if (toolName === 'list_directory') return handleListDirectoryTool(input, filePath);
+    if (toolName === 'read_file' || toolName === 'list_directory') {
+      const reason = rejectUnsafePath(toolInput.path);
+      if (reason) return reason;
+      const filePath = toolInput.path as string;
+      return toolName === 'read_file'
+        ? handleReadFileTool(input, filePath)
+        : handleListDirectoryTool(input, filePath);
+    }
     return `Error: Unknown tool: ${toolName}`;
   };
 }

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -590,7 +590,13 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     let tokensUsed = result.tokensUsed;
 
     if (!result.file) {
-      return { outcome: 'retry', failures: ['LLM call returned no usable content'], tokensUsed };
+      // Route the concrete parse reason (F-B) into the retry feedback via
+      // buildFailureContext, instead of the old generic message.
+      return {
+        outcome: 'retry',
+        failures: [result.reason ?? 'LLM call returned no usable content'],
+        tokensUsed,
+      };
     }
 
     let file = result.file;
@@ -668,7 +674,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     previouslyGenerated: GeneratedFile[];
     testGenTools?: { tools: LLMToolDefinition[]; toolHandler: ToolHandler };
     previousFailures?: string[];
-  }): Promise<{ file: GeneratedFile | null; tokensUsed: number; truncated: boolean }> {
+  }): Promise<{ file: GeneratedFile | null; tokensUsed: number; truncated: boolean; reason?: string }> {
     const { planItem, fullPlan, input, previouslyGenerated, testGenTools, previousFailures } = opts;
     const prompt = this.buildSingleTestFilePrompt({
       planItem,
@@ -678,15 +684,16 @@ export class ClaudeApiTestGenModule implements TestGenModule {
       previousFailures,
     });
     const response = await this.invokeLLM(prompt, testGenTools, planItem.filePath);
-    if (!response) return { file: null, tokensUsed: 0, truncated: false };
+    if (!response) return { file: null, tokensUsed: 0, truncated: false, reason: 'The LLM returned no response.' };
     const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
     const truncated = response.stopReason === 'max_tokens';
     // First-gen parse: hardened for CLI preamble/fence/prose (F-B). Continuation
     // chunks keep parseContinuationChunk (no preamble strip, M3a).
     const rawContent = libParseFirstGenFileContent(response.content);
 
-    if (!this.isUsableContent(rawContent, planItem.filePath, response.content.length)) {
-      return { file: null, tokensUsed, truncated: false };
+    const reason = this.unusableReason(rawContent, planItem.filePath, response.content.length);
+    if (reason) {
+      return { file: null, tokensUsed, truncated: false, reason };
     }
     return {
       file: { path: planItem.filePath, content: rawContent, purpose: planItem.description },
@@ -719,16 +726,19 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     }
   }
 
-  private isUsableContent(rawContent: string, filePath: string, rawCharCount: number): boolean {
+  /** Concrete reason the parsed content is unusable, or null if it is usable. */
+  private unusableReason(rawContent: string, filePath: string, rawCharCount: number): string | null {
     if (!rawContent || rawContent.length < 20) {
       console.log(`[Test Gen Module]   No usable content for ${filePath} (${rawCharCount} raw chars)`);
-      return false;
+      return `The response contained no usable code (only ${rawContent?.length ?? 0} chars after parsing). ` +
+        'Output ONLY the complete test file source, with no prose or explanation.';
     }
     if (!this.looksLikeCodeContent(rawContent, filePath)) {
       console.log(`[Test Gen Module]   Output for ${filePath} appears to be LLM reasoning, not code — skipping`);
-      return false;
+      return 'The response did not parse as code (likely leaked reasoning/prose or a stray markdown fence). ' +
+        'Output ONLY valid test code for the file — no preamble, headings, explanation, or ``` fences.';
     }
-    return true;
+    return null;
   }
 
   // ============================================================================

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -359,12 +359,29 @@ export class ClaudeApiTestGenModule implements TestGenModule {
    */
   private async resolveTargetPaths(plan: TestPlanItem[], input: TestGenModuleInput): Promise<void> {
     if (!input.readFile) return; // no existence check available: keep canonical paths
+    const kept: TestPlanItem[] = [];
     for (const item of plan) {
-      if (!(await this.pathExists(item.filePath, input))) continue;
+      if (!(await this.pathExists(item.filePath, input))) {
+        kept.push(item);
+        continue;
+      }
       const sibling = await this.nextFreeSiblingPath(item.filePath, input);
+      if (sibling === null) {
+        // Every sibling up to the cap exists (practically unreachable). Drop the
+        // item into the non-fatal 0-file path rather than return a possibly-
+        // existing path — preserves F-A's "never destroy by construction".
+        console.warn(
+          `[Test Gen Module] Skipping ${item.filePath}: all sibling paths up to the cap exist; refusing to overwrite.`
+        );
+        continue;
+      }
       console.log(`[Test Gen Module] Target spec exists; writing sibling instead: ${item.filePath} -> ${sibling}`);
       item.filePath = sibling;
+      kept.push(item);
     }
+    // Rebuild the plan in place so surfacePlan / generateTestFilesSequentially /
+    // validateAgainstManifest all see the resolved (and possibly reduced) set.
+    plan.splice(0, plan.length, ...kept);
   }
 
   private async pathExists(relPath: string, input: TestGenModuleInput): Promise<boolean> {
@@ -373,16 +390,17 @@ export class ClaudeApiTestGenModule implements TestGenModule {
   }
 
   /**
-   * First `.additional[.N]` sibling of filePath that does not already exist.
-   * Bounded (SIBLING_PATH_CAP) so a misbehaving readFile can never spin forever;
-   * hitting the cap is not reachable with a real cht-core tree.
+   * First `.additional[.N]` sibling of filePath that does NOT already exist, or
+   * null when every candidate up to SIBLING_PATH_CAP exists. Every returned path
+   * has passed a final existence check, so it is never a path that would clobber
+   * (the cap returns null instead of a possibly-existing path).
    */
-  private async nextFreeSiblingPath(filePath: string, input: TestGenModuleInput): Promise<string> {
-    let candidate = siblingSpecPath(filePath);
-    for (let n = 2; n <= SIBLING_PATH_CAP && (await this.pathExists(candidate, input)); n++) {
-      candidate = siblingSpecPath(filePath, n);
+  private async nextFreeSiblingPath(filePath: string, input: TestGenModuleInput): Promise<string | null> {
+    for (let n = 1; n <= SIBLING_PATH_CAP; n++) {
+      const candidate = siblingSpecPath(filePath, n === 1 ? undefined : n);
+      if (!(await this.pathExists(candidate, input))) return candidate;
     }
-    return candidate;
+    return null;
   }
 
   private logPostCallValidation(warnings: string[]): void {

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -16,7 +16,7 @@ import {
 import { readEnv } from '../../../../utils/env';
 import { isShutdownRequested } from '../../../../utils/shutdown';
 import {
-  TestPlanSchema,
+  TestPlanItemSchema,
   TestContentAssertions,
   RequirementsChecklistSchema,
 } from '../../schemas';
@@ -134,6 +134,38 @@ function decideRetryNext(
   return { kind: 'retry', failures: attempt.failures };
 }
 
+/**
+ * Return the first brace-balanced `{...}` object in `text`, or null. A linear
+ * O(n) scan (no backtracking, Sonar S8786-safe) from the first `{` to its
+ * matching `}`, skipping braces inside JSON strings (with escape handling) so a
+ * `}` in a string value or trailing prose after the object does not confuse it.
+ * Replaces a greedy `/\{[\s\S]*\}/` that anchored to the LAST `}` and
+ * over-captured trailing prose (making JSON.parse throw -> silent []).
+ */
+function extractFirstJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
 export class ClaudeApiTestGenModule implements TestGenModule {
   name = 'claude-api';
 
@@ -161,7 +193,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
 
     const planResult = await this.resolvePlan(input, llm.modelName);
     if (planResult.bailout) return planResult.bailout;
-    const { plan, planTokens } = planResult;
+    const { plan, planTokens, planWarnings } = planResult;
 
     this.surfacePlan(plan);
 
@@ -174,7 +206,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     this.logPostCallValidation(warnings);
     this.logGeneratedFiles(genResult.files);
 
-    const combinedWarnings = [...warnings, ...genResult.warnings];
+    const combinedWarnings = [...planWarnings, ...warnings, ...genResult.warnings];
 
     return {
       files: genResult.files,
@@ -236,14 +268,14 @@ export class ClaudeApiTestGenModule implements TestGenModule {
   private async resolvePlan(
     input: TestGenModuleInput,
     modelName: string,
-  ): Promise<{ plan: TestPlanItem[]; planTokens: number; bailout?: never }
-    | { bailout: TestGenModuleOutput; plan: TestPlanItem[]; planTokens: number }> {
+  ): Promise<{ plan: TestPlanItem[]; planTokens: number; planWarnings: string[]; bailout?: never }
+    | { bailout: TestGenModuleOutput; plan: TestPlanItem[]; planTokens: number; planWarnings: string[] }> {
     const failingTestFiles = readFailingTestFiles(input);
     if (failingTestFiles && failingTestFiles.length > 0) {
       console.log(
         `[Test Gen Module] Selective regeneration: reusing plan for ${failingTestFiles.length} failing file(s)`
       );
-      return { plan: [...failingTestFiles], planTokens: 0 };
+      return { plan: [...failingTestFiles], planTokens: 0, planWarnings: [] };
     }
 
     try {
@@ -253,21 +285,27 @@ export class ClaudeApiTestGenModule implements TestGenModule {
         return {
           plan: [],
           planTokens: planResult.tokensUsed,
+          planWarnings: planResult.warnings,
           bailout: {
             files: [],
             explanation: `No test plan generated for "${input.ticket.issue.title}".`,
             tokensUsed: planResult.tokensUsed,
             modelUsed: modelName,
             requirementsChecklist: [],
+            // Warnings only when items were dropped as invalid; a genuinely empty
+            // plan (no items at all) stays a warning-free intentional no-op so the
+            // supervisor does not mark the todo failed.
+            warnings: planResult.warnings.length > 0 ? planResult.warnings : undefined,
           },
         };
       }
-      return { plan: planResult.plan, planTokens: planResult.tokensUsed };
+      return { plan: planResult.plan, planTokens: planResult.tokensUsed, planWarnings: planResult.warnings };
     } catch (error) {
       console.error('[Test Gen Module] Plan generation failed:', error);
       return {
         plan: [],
         planTokens: 0,
+        planWarnings: [],
         bailout: {
           files: [],
           explanation: `Test generation failed for "${input.ticket.issue.title}".`,
@@ -307,23 +345,39 @@ export class ClaudeApiTestGenModule implements TestGenModule {
 
   private async generateTestPlan(
     input: TestGenModuleInput,
-  ): Promise<{ plan: TestPlanItem[]; tokensUsed: number }> {
+  ): Promise<{ plan: TestPlanItem[]; tokensUsed: number; warnings: string[] }> {
     const llm = this.getProvider();
     const prompt = this.buildTestPlanPrompt(input);
 
     const response = await llm.invoke(prompt, { temperature: 0.3, maxTokens: 8192, disableTools: true });
     const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
 
-    const plan = this.parseTestPlan(response.content);
-
-    const validation = TestPlanSchema.safeParse({ items: plan });
-    if (!validation.success) {
-      console.log(
-        `[Test Gen Module] Plan validation warnings: ${validation.error.issues.map(i => i.message).join(', ')}`
-      );
+    const parsed = this.parseTestPlan(response.content);
+    const { plan, warnings } = this.filterValidPlanItems(parsed);
+    for (const warning of warnings) {
+      console.log(`[Test Gen Module] Plan validation: ${warning}`);
     }
 
-    return { plan, tokensUsed };
+    return { plan, tokensUsed, warnings };
+  }
+
+  /**
+   * Keep only plan items that pass TestPlanItemSchema; drop the rest and return a
+   * warning per drop, so the schema is authoritative (not validate-and-ignore).
+   */
+  private filterValidPlanItems(items: TestPlanItem[]): { plan: TestPlanItem[]; warnings: string[] } {
+    const plan: TestPlanItem[] = [];
+    const warnings: string[] = [];
+    for (const item of items) {
+      const validation = TestPlanItemSchema.safeParse(item);
+      if (validation.success) {
+        plan.push(item);
+      } else {
+        const reasons = validation.error.issues.map(i => i.message).join('; ');
+        warnings.push(`Dropped invalid test-plan item "${item.filePath || '(no path)'}": ${reasons}`);
+      }
+    }
+    return { plan, warnings };
   }
 
   parseTestPlan(rawContent: string): TestPlanItem[] {
@@ -704,22 +758,21 @@ export class ClaudeApiTestGenModule implements TestGenModule {
   }
 
   parseRequirementsChecklist(rawContent: string): TestScenario[] {
-    const jsonMatch = /\{[\s\S]*\}/.exec(rawContent);
-    if (!jsonMatch) return [];
+    const json = extractFirstJsonObject(rawContent);
+    if (!json) return [];
 
     try {
-      const parsed = JSON.parse(jsonMatch[0]);
+      const parsed = JSON.parse(json);
       const validation = RequirementsChecklistSchema.safeParse(parsed);
       if (validation.success) {
         return validation.data.checklist;
       }
-      if (parsed.checklist && Array.isArray(parsed.checklist)) {
-        return parsed.checklist;
-      }
     } catch {
-      // Fall through
+      // Fall through to [].
     }
 
+    // Schema is authoritative: only validated data is returned; a parse/validation
+    // failure yields [] rather than the raw (previously unvalidated) checklist.
     return [];
   }
 

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -1064,41 +1064,6 @@ Output ONLY the JSON. No explanations.`;
     return lines.join('\n');
   }
 
-  /**
-   * Public back-compat extractor for raw LLM output.
-   * Preserves the existing test-gen behavior (markdown-fence strip + first
-   * code-line search) so external callers and the spec at
-   * test/layers/test-gen/claude-api-module.spec.ts continue to pass.
-   * Internally the per-file generation path uses {@link parseSingleFileContent}
-   * (lib helper) for reasoning-preamble protection.
-   */
-  extractCodeContent(rawContent: string): string {
-    let content = rawContent.trim();
-
-    const codeBlockMatch = /^```(?:\w+)?\n([\s\S]*?)\n```$/.exec(content);
-    if (codeBlockMatch) {
-      content = codeBlockMatch[1];
-    }
-
-    const lines = content.split('\n');
-    let codeStartIdx = 0;
-    for (let i = 0; i < Math.min(lines.length, 10); i++) {
-      const line = lines[i].trim();
-      if (
-        line.startsWith('import ') || line.startsWith('const ') ||
-        line.startsWith('require(') || line.startsWith("'use strict'") ||
-        line.startsWith('"use strict"') || line.startsWith('/**') ||
-        line.startsWith('//') || line.startsWith('describe(') ||
-        line.startsWith('module.')
-      ) {
-        codeStartIdx = i;
-        break;
-      }
-    }
-
-    return lines.slice(codeStartIdx).join('\n').trim();
-  }
-
   // ============================================================================
   // Validation
   // ============================================================================

--- a/src/layers/test-gen/modules/claude-api/index.ts
+++ b/src/layers/test-gen/modules/claude-api/index.ts
@@ -142,26 +142,39 @@ function decideRetryNext(
  * Replaces a greedy `/\{[\s\S]*\}/` that anchored to the LAST `}` and
  * over-captured trailing prose (making JSON.parse throw -> silent []).
  */
+interface JsonScanState { depth: number; inString: boolean; escaped: boolean; }
+
+/** Advance the in-string escape/quote state for one character (called while inString). */
+function updateStringState(state: JsonScanState, ch: string): void {
+  if (state.escaped) state.escaped = false;
+  else if (ch === '\\') state.escaped = true;
+  else if (ch === '"') state.inString = false;
+}
+
+/**
+ * Feed one character to the brace scanner. Returns true exactly when the outermost
+ * object just closed (depth returned to 0 on a `}`).
+ */
+function consumeJsonChar(state: JsonScanState, ch: string): boolean {
+  if (state.inString) {
+    updateStringState(state, ch);
+    return false;
+  }
+  if (ch === '"') state.inString = true;
+  else if (ch === '{') state.depth++;
+  else if (ch === '}') {
+    state.depth--;
+    return state.depth === 0;
+  }
+  return false;
+}
+
 function extractFirstJsonObject(text: string): string | null {
   const start = text.indexOf('{');
   if (start === -1) return null;
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
+  const state: JsonScanState = { depth: 0, inString: false, escaped: false };
   for (let i = start; i < text.length; i++) {
-    const ch = text[i];
-    if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === '\\') escaped = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') inString = true;
-    else if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return text.slice(start, i + 1);
-    }
+    if (consumeJsonChar(state, text[i])) return text.slice(start, i + 1);
   }
   return null;
 }
@@ -183,6 +196,11 @@ export function siblingSpecPath(filePath: string, counter?: number): string {
   if (m) return `${m[1]}${suffix}${m[2]}${m[3]}`;
   const ext = path.extname(filePath);
   return `${filePath.slice(0, filePath.length - ext.length)}${suffix}${ext}`;
+}
+
+/** The array when it has entries, else undefined (the intentional-no-op warnings signal). */
+function undefinedIfEmpty<T>(arr: T[]): T[] | undefined {
+  return arr.length > 0 ? arr : undefined;
 }
 
 export class ClaudeApiTestGenModule implements TestGenModule {
@@ -240,7 +258,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
       tokensUsed: totalTokens,
       modelUsed: llm.modelName,
       requirementsChecklist: checklist,
-      warnings: combinedWarnings.length > 0 ? combinedWarnings : undefined,
+      warnings: undefinedIfEmpty(combinedWarnings),
     };
   }
 
@@ -319,7 +337,7 @@ export class ClaudeApiTestGenModule implements TestGenModule {
             // Warnings only when items were dropped as invalid; a genuinely empty
             // plan (no items at all) stays a warning-free intentional no-op so the
             // supervisor does not mark the todo failed.
-            warnings: planResult.warnings.length > 0 ? planResult.warnings : undefined,
+            warnings: undefinedIfEmpty(planResult.warnings),
           },
         };
       }
@@ -361,27 +379,38 @@ export class ClaudeApiTestGenModule implements TestGenModule {
     if (!input.readFile) return; // no existence check available: keep canonical paths
     const kept: TestPlanItem[] = [];
     for (const item of plan) {
-      if (!(await this.pathExists(item.filePath, input))) {
-        kept.push(item);
-        continue;
-      }
-      const sibling = await this.nextFreeSiblingPath(item.filePath, input);
-      if (sibling === null) {
-        // Every sibling up to the cap exists (practically unreachable). Drop the
-        // item into the non-fatal 0-file path rather than return a possibly-
-        // existing path — preserves F-A's "never destroy by construction".
-        console.warn(
-          `[Test Gen Module] Skipping ${item.filePath}: all sibling paths up to the cap exist; refusing to overwrite.`
-        );
-        continue;
-      }
-      console.log(`[Test Gen Module] Target spec exists; writing sibling instead: ${item.filePath} -> ${sibling}`);
-      item.filePath = sibling;
-      kept.push(item);
+      const resolved = await this.resolveItemPath(item, input);
+      if (resolved !== null) kept.push(resolved);
     }
     // Rebuild the plan in place so surfacePlan / generateTestFilesSequentially /
     // validateAgainstManifest all see the resolved (and possibly reduced) set.
     plan.splice(0, plan.length, ...kept);
+  }
+
+  /**
+   * Resolve one plan item's target path (F-A): keep it as-is when its canonical
+   * spec does not exist, redirect it in place to a free `*.additional.spec.*`
+   * sibling when it does, or return null to DROP it when every sibling up to the
+   * cap exists (never returns a path that would clobber existing coverage).
+   */
+  private async resolveItemPath(
+    item: TestPlanItem,
+    input: TestGenModuleInput,
+  ): Promise<TestPlanItem | null> {
+    if (!(await this.pathExists(item.filePath, input))) return item;
+    const sibling = await this.nextFreeSiblingPath(item.filePath, input);
+    if (sibling === null) {
+      // Every sibling up to the cap exists (practically unreachable). Drop the
+      // item into the non-fatal 0-file path rather than return a possibly-
+      // existing path — preserves F-A's "never destroy by construction".
+      console.warn(
+        `[Test Gen Module] Skipping ${item.filePath}: all sibling paths up to the cap exist; refusing to overwrite.`
+      );
+      return null;
+    }
+    console.log(`[Test Gen Module] Target spec exists; writing sibling instead: ${item.filePath} -> ${sibling}`);
+    item.filePath = sibling;
+    return item;
   }
 
   private async pathExists(relPath: string, input: TestGenModuleInput): Promise<boolean> {
@@ -1147,7 +1176,8 @@ Output ONLY the JSON. No explanations.`;
   private stripDanglingFences(content: string): string {
     const lines = content.split('\n');
     if (lines.length > 0 && /^```[\w-]*\s*$/.test(lines[0])) lines.shift();
-    if (lines.length > 0 && /^```\s*$/.test(lines[lines.length - 1])) lines.pop();
+    const last = lines.at(-1);
+    if (last !== undefined && /^```\s*$/.test(last)) lines.pop();
     return lines.join('\n');
   }
 

--- a/src/layers/test-gen/modules/claude-code-cli/README.md
+++ b/src/layers/test-gen/modules/claude-code-cli/README.md
@@ -1,0 +1,3 @@
+# Claude Code CLI Test Module
+
+Placeholder directory for a future `claude-code-cli` test generation module implementation.

--- a/src/layers/test-gen/modules/opencode/README.md
+++ b/src/layers/test-gen/modules/opencode/README.md
@@ -1,0 +1,3 @@
+# OpenCode Test Module
+
+Placeholder directory for a future `opencode` test generation module implementation.

--- a/src/layers/test-gen/registry.ts
+++ b/src/layers/test-gen/registry.ts
@@ -1,0 +1,57 @@
+import { TestGenModule } from './interface';
+import { createClaudeApiTestGenModule } from './modules/claude-api';
+import { LLMProvider } from '../../llm';
+import { readEnv } from '../../utils/env';
+
+const PROVIDER_ALIAS_MAP: Record<string, string> = {
+  anthropic: 'claude-api',
+  'claude-cli': 'claude-code-cli',
+};
+
+export class TestGenModuleRegistry {
+  private readonly modules = new Map<string, TestGenModule>();
+
+  register(module: TestGenModule): void {
+    if (this.modules.has(module.name)) {
+      throw new Error(
+        `Test generation module "${module.name}" is already registered. Use a unique name for each module.`
+      );
+    }
+    this.modules.set(module.name, module);
+  }
+
+  get(moduleName: string): TestGenModule | undefined {
+    return this.modules.get(moduleName);
+  }
+
+  list(): string[] {
+    return Array.from(this.modules.keys());
+  }
+
+  resolveProvider(provider: string): string {
+    return PROVIDER_ALIAS_MAP[provider] || provider;
+  }
+
+  getActiveModule(providerFromConfig?: string): TestGenModule {
+    const requestedProvider = providerFromConfig || readEnv('TEST_GEN_MODULE') || 'claude-api';
+    const moduleName = this.resolveProvider(requestedProvider);
+    const module = this.get(moduleName);
+
+    if (!module) {
+      const available = this.list();
+      throw new Error(
+        `No test generation module registered for provider "${requestedProvider}" (resolved to "${moduleName}"). Registered modules: ${available.join(', ') || 'none'}`
+      );
+    }
+
+    return module;
+  }
+}
+
+export function createDefaultTestGenRegistry(llmProvider?: LLMProvider): TestGenModuleRegistry {
+  const registry = new TestGenModuleRegistry();
+
+  registry.register(createClaudeApiTestGenModule(llmProvider));
+
+  return registry;
+}

--- a/src/layers/test-gen/registry.ts
+++ b/src/layers/test-gen/registry.ts
@@ -5,7 +5,6 @@ import { readEnv } from '../../utils/env';
 
 const PROVIDER_ALIAS_MAP: Record<string, string> = {
   anthropic: 'claude-api',
-  'claude-cli': 'claude-code-cli',
 };
 
 export class TestGenModuleRegistry {

--- a/src/layers/test-gen/registry.ts
+++ b/src/layers/test-gen/registry.ts
@@ -5,6 +5,11 @@ import { readEnv } from '../../utils/env';
 
 const PROVIDER_ALIAS_MAP: Record<string, string> = {
   anthropic: 'claude-api',
+  // The single test-gen module is provider-agnostic: it runs via `claude -p` when
+  // LLM_PROVIDER=claude-cli (text-only, disableTools). So claude-cli selects it,
+  // keeping TEST_GEN_MODULE symmetric with CODE_GEN_MODULE. A genuinely-unknown
+  // value still passes through to get() and throws (honest failure preserved).
+  'claude-cli': 'claude-api',
 };
 
 export class TestGenModuleRegistry {

--- a/src/layers/test-gen/schemas.ts
+++ b/src/layers/test-gen/schemas.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+import * as ts from 'typescript';
+
+function scriptKindFromPath(filePath: string): ts.ScriptKind {
+  if (/\.tsx$/i.test(filePath)) return ts.ScriptKind.TSX;
+  if (/\.jsx$/i.test(filePath)) return ts.ScriptKind.JSX;
+  if (/\.js$/i.test(filePath)) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+export const TestPlanItemSchema = z.object({
+  filePath: z.string().min(3).regex(/\.spec\.\w+$|\.test\.\w+$/, 'Test file path must end with .spec.* or .test.*'),
+  testType: z.enum(['unit', 'integration', 'e2e']),
+  targetSourceFile: z.string().min(1),
+  description: z.string().min(10, 'Description must be at least 10 characters'),
+});
+
+export const TestPlanSchema = z.object({
+  items: z.array(TestPlanItemSchema).min(1, 'Test plan must have at least one item'),
+});
+
+export const TestScenarioSchema = z.object({
+  requirement: z.string().min(1),
+  scenarios: z.array(z.object({
+    name: z.string().min(1),
+    type: z.enum(['happy-path', 'error', 'edge-case', 'boundary']),
+    description: z.string().min(1),
+  })).min(1),
+});
+
+export const RequirementsChecklistSchema = z.object({
+  checklist: z.array(TestScenarioSchema),
+});
+
+export type ValidatedTestPlanItem = z.infer<typeof TestPlanItemSchema>;
+export type ValidatedTestPlan = z.infer<typeof TestPlanSchema>;
+
+const TEST_STRUCTURE_PATTERNS = [
+  /describe\s*\(/,
+  /it\s*\(/,
+  /test\s*\(/,
+  /expect\s*\(/,
+  /assert\s*[.(]/,
+  /should\s*[.(]/,
+];
+
+
+export const TestContentAssertions = {
+  hasTestStructure(content: string): string[] {
+    const failures: string[] = [];
+
+    const hasDescribe = /describe\s*\(/.test(content);
+    const hasIt = /it\s*\(/.test(content) || /test\s*\(/.test(content);
+
+    if (!hasDescribe) {
+      failures.push('Test file missing describe() block');
+    }
+    if (!hasIt) {
+      failures.push('Test file missing it() or test() blocks');
+    }
+
+    return failures;
+  },
+
+  hasAssertions(content: string): string[] {
+    const failures: string[] = [];
+
+    const hasAssertion = TEST_STRUCTURE_PATTERNS.some(p => p.test(content));
+    if (!hasAssertion) {
+      failures.push('Test file contains no assertions (expect/assert/should)');
+    }
+
+    return failures;
+  },
+
+  hasProperImports(content: string, filePath: string): string[] {
+    const failures: string[] = [];
+
+    const hasImport = /^(import |const .* = require\()/m.test(content);
+    if (!hasImport) {
+      failures.push(`Test file ${filePath} has no import/require statements`);
+    }
+
+    return failures;
+  },
+
+  isNotPlaintext(content: string): string[] {
+    const failures: string[] = [];
+
+    const lines = content.split('\n').filter(l => l.trim().length > 0);
+    const nonCommentLines = lines.filter(
+      l => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('#') && !l.trim().startsWith('/*')
+    );
+
+    if (nonCommentLines.length === 0) {
+      failures.push('Test file content is empty or only comments');
+      return failures;
+    }
+
+    const firstFew = nonCommentLines.slice(0, 5).join('\n');
+    const plaintextIndicators = [
+      /^this (test |file )/im,
+      /^here('s| is) (a |the )?test/im,
+      /^i (would|will|should) /im,
+      /^to test this/im,
+    ];
+
+    for (const pattern of plaintextIndicators) {
+      if (pattern.test(firstFew)) {
+        failures.push('Content appears to be a plaintext description rather than test code');
+        break;
+      }
+    }
+
+    return failures;
+  },
+
+  /**
+   * Reject content that does not parse as JS/TS. The structure/import/assertion
+   * checks above only look for the PRESENCE of substrings (describe/it/require),
+   * so a file with a leaked LLM reasoning preamble ("...Here is the test file:")
+   * ahead of otherwise-valid code passes them while failing `node --check`. A
+   * syntactic parse (language-correct for .ts/.tsx/.js/.jsx via the script kind)
+   * catches that class, and the failure feeds the regenerate loop.
+   */
+  parsesAsCode(content: string, filePath: string): string[] {
+    const sourceFile = ts.createSourceFile(
+      filePath || 'test.ts',
+      content,
+      ts.ScriptTarget.Latest,
+      false,
+      scriptKindFromPath(filePath),
+    );
+    const diagnostics =
+      (sourceFile as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] }).parseDiagnostics ?? [];
+    if (diagnostics.length === 0) return [];
+    const message = ts.flattenDiagnosticMessageText(diagnostics[0].messageText, ' ');
+    return [`Test file ${filePath} does not parse as code (likely leaked prose/preamble): ${message}`];
+  },
+
+  validateTestFile(content: string, filePath: string): string[] {
+    return [
+      ...this.parsesAsCode(content, filePath),
+      ...this.isNotPlaintext(content),
+      ...this.hasProperImports(content, filePath),
+      ...this.hasTestStructure(content),
+      ...this.hasAssertions(content),
+    ];
+  },
+};

--- a/src/layers/test-gen/schemas.ts
+++ b/src/layers/test-gen/schemas.ts
@@ -124,6 +124,10 @@ export const TestContentAssertions = {
    * ahead of otherwise-valid code passes them while failing `node --check`. A
    * syntactic parse (language-correct for .ts/.tsx/.js/.jsx via the script kind)
    * catches that class, and the failure feeds the regenerate loop.
+   *
+   * LIMIT (M7): this reads parse diagnostics only — it catches SYNTAX errors, not
+   * type errors or unresolved imports, so "passes" does not mean "compiles". The
+   * real type/compile check is the deferred compile/coverage gate (see the #115 doc).
    */
   parsesAsCode(content: string, filePath: string): string[] {
     const sourceFile = ts.createSourceFile(

--- a/src/layers/test-gen/schemas.ts
+++ b/src/layers/test-gen/schemas.ts
@@ -35,13 +35,15 @@ export const RequirementsChecklistSchema = z.object({
 export type ValidatedTestPlanItem = z.infer<typeof TestPlanItemSchema>;
 export type ValidatedTestPlan = z.infer<typeof TestPlanSchema>;
 
-const TEST_STRUCTURE_PATTERNS = [
-  /describe\s*\(/,
-  /it\s*\(/,
-  /test\s*\(/,
-  /expect\s*\(/,
-  /assert\s*[.(]/,
-  /should\s*[.(]/,
+// Assertion-only, anchored: a real assertion CALL, not test structure or an
+// import. Excludes describe/it/test (structure, checked separately) and a bare
+// `chai`/`should` (so `import { expect } from 'chai'` alone does not satisfy the
+// gate). `.should` needs the property form (`x.should.equal`), not the import.
+const ASSERTION_PATTERNS = [
+  /\bexpect\s*\(/,
+  /\bassert\s*[.(]/,
+  /\.should\b/,
+  /sinon\.assert/,
 ];
 
 
@@ -65,7 +67,7 @@ export const TestContentAssertions = {
   hasAssertions(content: string): string[] {
     const failures: string[] = [];
 
-    const hasAssertion = TEST_STRUCTURE_PATTERNS.some(p => p.test(content));
+    const hasAssertion = ASSERTION_PATTERNS.some(p => p.test(content));
     if (!hasAssertion) {
       failures.push('Test file contains no assertions (expect/assert/should)');
     }

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -13,7 +13,7 @@
  * loops back to code generation with feedback (up to MAX_ITERATIONS).
  */
 
-import { StateGraph, START, Annotation } from '@langchain/langgraph';
+import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
 import {
   IssueTemplate,
   DevelopmentState,
@@ -24,11 +24,13 @@ import {
   ContextAnalysisResult,
   CodeGenerationResult,
   ImplementationValidation,
+  TestGenerationResult,
   GeneratedFile,
   FileValidationFeedback,
   FailingFileRef,
 } from '../types';
 import { CodeGenerationAgent } from '../agents/code-generation-agent';
+import { TestGenerationAgent, TestGenerationInput } from '../agents/test-generation-agent';
 import { CodeGenModuleRegistry } from '../layers/code-gen/registry';
 import { LLMProvider, createLLMProviderFromEnv } from '../llm';
 import {
@@ -170,6 +172,10 @@ const DevelopmentStateAnnotation = Annotation.Root({
     reducer: (_current, update) => update ?? _current,
     default: () => undefined,
   }),
+  testGeneration: Annotation<TestGenerationResult | undefined>({
+    reducer: (_current, update) => update ?? _current,
+    default: () => undefined,
+  }),
   currentPhase: Annotation<DevelopmentState['currentPhase']>({
     reducer: (_current, update) => update,
     default: () => 'init' as const,
@@ -197,6 +203,7 @@ const DevelopmentStateAnnotation = Annotation.Root({
 export class DevelopmentSupervisor {
   private readonly graph: ReturnType<typeof this.buildGraph>;
   private readonly codeGenAgent: CodeGenerationAgent;
+  private readonly testGenAgent: TestGenerationAgent;
   private readonly llm: LLMProvider;
   private readonly todos: TodoTracker;
 
@@ -207,6 +214,8 @@ export class DevelopmentSupervisor {
       llmProvider: this.llm,
       codeGenRegistry: options.codeGenRegistry,
     });
+
+    this.testGenAgent = new TestGenerationAgent({ llmProvider: this.llm });
 
     this.todos = createSupervisorTodoTracker('Development');
 
@@ -221,11 +230,26 @@ export class DevelopmentSupervisor {
       // Define nodes
       .addNode('generateCode', this.codeGenerationNode.bind(this))
       .addNode('validateImpl', this.validationNode.bind(this))
+      // Node name is 'generateTests' (not 'testGeneration'): LangGraph forbids a
+      // node name that collides with a state channel, and 'testGeneration' is the
+      // channel this node writes.
+      .addNode('generateTests', this.testGenerationNode.bind(this))
 
-      // Define edges with conditional routing from validation
+      // Define edges with conditional routing from validation. The resolver
+      // stays pure (returns 'generateCode' | END); the path map remaps its
+      // terminal branch through the test-generation node before END, while the
+      // refinement self-loop back to generateCode is unchanged.
       .addEdge(START, 'generateCode')
       .addEdge('generateCode', 'validateImpl')
-      .addConditionalEdges('validateImpl', (state) => resolveValidateImplEdge(state));
+      .addConditionalEdges(
+        'validateImpl',
+        (state) => resolveValidateImplEdge(state),
+        {
+          generateCode: 'generateCode',
+          [END]: 'generateTests',
+        },
+      )
+      .addEdge('generateTests', END);
 
     return workflow.compile();
   }
@@ -392,7 +416,10 @@ export class DevelopmentSupervisor {
   ): Record<string, unknown> {
     const feedbackUpdate: Record<string, unknown> = {
       validationResult: validation,
-      currentPhase: 'complete' as const,
+      // Validation is done; the terminal testGeneration node owns 'complete'.
+      // The resolver routes on score/issues, not on currentPhase, so this is
+      // routing-inert. A refinement-loop iteration overwrites it on re-entry.
+      currentPhase: 'test-generation' as const,
       messages: [
         {
           role: 'assistant' as const,
@@ -409,6 +436,86 @@ export class DevelopmentSupervisor {
     }
 
     return feedbackUpdate;
+  }
+
+  /**
+   * Node: Test Generation.
+   *
+   * Terminal node, reachable after the validation branch and outside the
+   * refinement loop, so it owns the final progress-tracker bookkeeping and printSummary.
+   * It builds input via buildTestGenModuleInput and runs the test-gen agent.
+   *
+   * Failure is non-fatal: it logs a warning and returns an empty result. It
+   * never writes errors/validationFeedback/perFileFeedback, so test generation
+   * cannot feed the validation score or trip the refinement loop. It no-ops on
+   * shutdown and when there is no generated code to test.
+   */
+  private async testGenerationNode(
+    state: typeof DevelopmentStateAnnotation.State,
+  ): Promise<{ testGeneration: TestGenerationResult; currentPhase: 'complete' }> {
+    const todoId = 'development-3';
+    const emptyResult: TestGenerationResult = { files: [], explanation: '', requirementsChecklist: [] };
+
+    if (isShutdownRequested()) {
+      console.log('[Development Supervisor] Shutdown requested; skipping test generation node');
+      return this.finishTestGeneration(todoId, emptyResult);
+    }
+
+    console.log('\n=== TEST GENERATION NODE ===');
+
+    if (!state.issue || !state.options || !state.researchFindings || !state.orchestrationPlan) {
+      console.log('[Development Supervisor] Skipping test generation — missing required data');
+      return this.finishTestGeneration(todoId, emptyResult);
+    }
+    if (!state.codeGeneration || state.codeGeneration.files.length === 0) {
+      console.log('[Development Supervisor] Skipping test generation — no generated code to test');
+      return this.finishTestGeneration(todoId, emptyResult);
+    }
+
+    const input: TestGenerationInput = {
+      issue: state.issue,
+      researchFindings: state.researchFindings,
+      orchestrationPlan: state.orchestrationPlan,
+      codeGeneration: state.codeGeneration,
+      chtCorePath: state.options.chtCorePath,
+    };
+    return this.runTestGenWithFallback(input, todoId, emptyResult);
+  }
+
+  /**
+   * Run the test-gen agent and finish the node, with the non-fatal fallback: a
+   * generation failure logs a warning and returns an empty result so the run
+   * completes. Extracted from testGenerationNode to keep that method flat.
+   */
+  private async runTestGenWithFallback(
+    input: TestGenerationInput,
+    todoId: string,
+    emptyResult: TestGenerationResult,
+  ): Promise<{ testGeneration: TestGenerationResult; currentPhase: 'complete' }> {
+    this.todos.start(todoId);
+    try {
+      const result = await this.testGenAgent.generate(input);
+      console.log(`[Development Supervisor] Generated ${result.files.length} test file(s)`);
+      return this.finishTestGeneration(todoId, result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      console.warn(`[Development Supervisor] Test generation failed (non-fatal): ${message}`);
+      return this.finishTestGeneration(todoId, emptyResult);
+    }
+  }
+
+  /**
+   * Complete the test-generation tracker entry, print the terminal run summary, and
+   * return the terminal state update. Shared by every testGenerationNode path
+   * so the summary fires exactly once and reads 3/3 at the end of a run.
+   */
+  private finishTestGeneration(
+    todoId: string,
+    result: TestGenerationResult,
+  ): { testGeneration: TestGenerationResult; currentPhase: 'complete' } {
+    this.todos.complete(todoId);
+    this.todos.printSummary();
+    return { testGeneration: result, currentPhase: 'complete' as const };
   }
 
   /**
@@ -725,6 +832,7 @@ Respond with a JSON object:
     this.todos.addMany([
       { content: 'Generate code', activeForm: 'Generating code' },
       { content: 'Validate implementation', activeForm: 'Validating implementation' },
+      { content: 'Generate tests', activeForm: 'Generating tests' },
     ]);
 
     const initialState: typeof DevelopmentStateAnnotation.State = {
@@ -741,6 +849,7 @@ Respond with a JSON object:
       contextAnalysis: input.contextAnalysis,
       options: input.options,
       codeGeneration: undefined,
+      testGeneration: undefined,
       validationResult: undefined,
       currentPhase: 'init',
       errors: [],
@@ -786,6 +895,10 @@ Respond with a JSON object:
       allFiles.push(...state.codeGeneration.files);
     }
 
+    if (state.testGeneration) {
+      allFiles.push(...state.testGeneration.files);
+    }
+
     const writtenFiles = await writeToStaging(allFiles, stagingPath);
 
     console.log(`[Development Supervisor] Written ${writtenFiles.length} files to staging: ${stagingPath}`);
@@ -801,6 +914,10 @@ Respond with a JSON object:
 
     if (state.codeGeneration) {
       allFiles.push(...state.codeGeneration.files);
+    }
+
+    if (state.testGeneration) {
+      allFiles.push(...state.testGeneration.files);
     }
 
     const writtenFiles = await writeToChtCore(allFiles, chtCorePath);

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -478,6 +478,9 @@ export class DevelopmentSupervisor {
       orchestrationPlan: state.orchestrationPlan,
       codeGeneration: state.codeGeneration,
       chtCorePath: state.options.chtCorePath,
+      // Thread refinement feedback into test-gen (mirrors codeGenerationNode), so
+      // the "Feedback from Previous Iteration" prompt branch is actually fed (M6).
+      additionalContext: state.validationFeedback || undefined,
     };
     return this.runTestGenWithFallback(input, todoId, emptyResult);
   }

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -63,8 +63,16 @@ function renderBulletSection<T>(heading: string, items: T[], format: (item: T) =
 export interface ValidateImplEdgeState {
   validationResult?: { overallScore?: number };
   iterationCount?: number;
-  codeGeneration?: { crossFileIssues?: { issueType?: string }[] };
+  codeGeneration?: { crossFileIssues?: { issueType?: string }[]; files?: unknown[] };
 }
+
+/**
+ * Cross-file issue types that are advisory, not blocking (F-C): the CLI code-gen
+ * module's reconcilePlanAdherence emits these for a valid file touched outside the
+ * narrow HC1 plan. They must NOT re-trigger the refinement loop (they stay visible
+ * in the HC2 banner, which reads crossFileIssues directly).
+ */
+const WARN_ONLY_ISSUE_TYPES = new Set(['plan-adherence-extra', 'plan-adherence-missing']);
 
 /**
  * Decide what edge the validateImpl node should take next. Pure function so
@@ -90,9 +98,19 @@ export function resolveValidateImplEdge(state: ValidateImplEdgeState): 'generate
     console.log('[Development Supervisor] execute-no-op detected; ending workflow (refinement loop cannot help)');
     return '__end__';
   }
-  const belowBar = score < REFINEMENT_THRESHOLD || issues.length > 0;
+  // F-C: 0 files cannot be improved by looping, and on a 0-file re-iteration
+  // reconcilePlanAdherence flips every plan path to plan-adherence-missing, which
+  // would otherwise keep belowBar true forever. End cleanly (the guard lives here,
+  // not validationNode, because the resolver ignores currentPhase).
+  if ((state.codeGeneration?.files?.length ?? 0) === 0) {
+    console.log('[Development Supervisor] 0 files generated; ending workflow (refinement loop cannot help)');
+    return '__end__';
+  }
+  // Only BLOCKING issues re-trigger refinement; plan-adherence-* are warn-only.
+  const blockingIssues = issues.filter(i => !WARN_ONLY_ISSUE_TYPES.has(i.issueType ?? ''));
+  const belowBar = score < REFINEMENT_THRESHOLD || blockingIssues.length > 0;
   if (belowBar && iterations < MAX_ITERATIONS) {
-    logRefinementLoop(score, issues, iterations);
+    logRefinementLoop(score, blockingIssues, iterations);
     return 'generateCode';
   }
   if (belowBar) {
@@ -126,10 +144,10 @@ function checkAcceptanceCriteria(issue: IssueTemplate, codeGen: CodeGenerationRe
   });
 }
 
-function logRefinementLoop(score: number, issues: { issueType?: string }[], iterations: number): void {
+function logRefinementLoop(score: number, blockingIssues: { issueType?: string }[], iterations: number): void {
   const reason = score < REFINEMENT_THRESHOLD
     ? `Score ${score}% < ${REFINEMENT_THRESHOLD}% threshold`
-    : `${issues.length} cross-file issue(s)`;
+    : `${blockingIssues.length} blocking cross-file issue(s)`;
   console.log(`[Development Supervisor] ${reason}, iteration ${iterations + 1}/${MAX_ITERATIONS} — looping back to code generation`);
 }
 

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -83,29 +83,41 @@ const WARN_ONLY_ISSUE_TYPES = new Set(['plan-adherence-extra', 'plan-adherence-m
  *  - Score below threshold OR any cross-file issue → 'generateCode' (refine) if iterations left
  *  - Otherwise → '__end__'
  */
-export function resolveValidateImplEdge(state: ValidateImplEdgeState): 'generateCode' | '__end__' {
+/**
+ * Log message for an unconditional early-END (shutdown, execute-no-op, or 0 files),
+ * or null when none applies. Reads crossFileIssues but never mutates state, so the
+ * HC2 banner still sees the full issue set.
+ */
+function earlyEndReason(state: ValidateImplEdgeState): string | null {
   if (isShutdownRequested()) {
-    console.log('[Development Supervisor] Shutdown requested; ending workflow');
-    return '__end__';
+    return 'Shutdown requested; ending workflow';
   }
-  const score = state.validationResult?.overallScore ?? 0;
-  const iterations = state.iterationCount ?? 0;
   const issues = state.codeGeneration?.crossFileIssues ?? [];
   // R17 (v7): when the CLI abstained even after the relaxed retry, looping
   // cannot help — it would just repeat the same abstain pattern with the
   // same plan. End cleanly so the user sees the HC2 banner.
   if (issues.some(i => i.issueType === 'execute-no-op')) {
-    console.log('[Development Supervisor] execute-no-op detected; ending workflow (refinement loop cannot help)');
-    return '__end__';
+    return 'execute-no-op detected; ending workflow (refinement loop cannot help)';
   }
   // F-C: 0 files cannot be improved by looping, and on a 0-file re-iteration
   // reconcilePlanAdherence flips every plan path to plan-adherence-missing, which
   // would otherwise keep belowBar true forever. End cleanly (the guard lives here,
   // not validationNode, because the resolver ignores currentPhase).
   if ((state.codeGeneration?.files?.length ?? 0) === 0) {
-    console.log('[Development Supervisor] 0 files generated; ending workflow (refinement loop cannot help)');
+    return '0 files generated; ending workflow (refinement loop cannot help)';
+  }
+  return null;
+}
+
+export function resolveValidateImplEdge(state: ValidateImplEdgeState): 'generateCode' | '__end__' {
+  const end = earlyEndReason(state);
+  if (end !== null) {
+    console.log(`[Development Supervisor] ${end}`);
     return '__end__';
   }
+  const score = state.validationResult?.overallScore ?? 0;
+  const iterations = state.iterationCount ?? 0;
+  const issues = state.codeGeneration?.crossFileIssues ?? [];
   // Only BLOCKING issues re-trigger refinement; plan-adherence-* are warn-only.
   const blockingIssues = issues.filter(i => !WARN_ONLY_ISSUE_TYPES.has(i.issueType ?? ''));
   const belowBar = score < REFINEMENT_THRESHOLD || blockingIssues.length > 0;

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -496,11 +496,23 @@ export class DevelopmentSupervisor {
     try {
       const result = await this.testGenAgent.generate(input);
       console.log(`[Development Supervisor] Generated ${result.files.length} test file(s)`);
+      // A no-file result that carries warnings means work was attempted and lost
+      // (all plan items dropped, or every file failed the content gate) — report
+      // it as a failed todo, not a green no-op. A warning-free empty result is an
+      // intentional no-op (e.g. genuinely empty plan) and stays complete.
+      if (result.files.length === 0 && (result.warnings?.length ?? 0) > 0) {
+        return this.failTestGeneration(
+          todoId,
+          result,
+          `Test generation produced no files: ${result.warnings!.join('; ')}`,
+        );
+      }
       return this.finishTestGeneration(todoId, result);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       console.warn(`[Development Supervisor] Test generation failed (non-fatal): ${message}`);
-      return this.finishTestGeneration(todoId, emptyResult);
+      const reason = `Test generation failed: ${message}`;
+      return this.failTestGeneration(todoId, { ...emptyResult, warnings: [reason] }, reason);
     }
   }
 
@@ -514,6 +526,23 @@ export class DevelopmentSupervisor {
     result: TestGenerationResult,
   ): { testGeneration: TestGenerationResult; currentPhase: 'complete' } {
     this.todos.complete(todoId);
+    this.todos.printSummary();
+    return { testGeneration: result, currentPhase: 'complete' as const };
+  }
+
+  /**
+   * Mark the test-generation tracker entry FAILED (with a reason) and print the
+   * terminal summary. Test generation stays non-fatal: currentPhase remains
+   * 'complete' and no errors/validationFeedback/perFileFeedback are written, so
+   * it can never feed the validation score or trip the refinement loop — only the
+   * todo/summary reflects the failure.
+   */
+  private failTestGeneration(
+    todoId: string,
+    result: TestGenerationResult,
+    reason: string,
+  ): { testGeneration: TestGenerationResult; currentPhase: 'complete' } {
+    this.todos.fail(todoId, reason);
     this.todos.printSummary();
     return { testGeneration: result, currentPhase: 'complete' as const };
   }

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -531,8 +531,8 @@ export class DevelopmentSupervisor {
       console.log(`[Development Supervisor] Generated ${result.files.length} test file(s)`);
       // A no-file result that carries warnings means work was attempted and lost
       // (all plan items dropped, or every file failed the content gate) — report
-      // it as a failed todo, not a green no-op. A warning-free empty result is an
-      // intentional no-op (e.g. genuinely empty plan) and stays complete.
+      // it as a failed TodoTracker entry, not a green no-op. A warning-free empty
+      // result is an intentional no-op (e.g. genuinely empty plan) and stays complete.
       if (result.files.length === 0 && (result.warnings?.length ?? 0) > 0) {
         return this.failTestGeneration(
           todoId,
@@ -568,7 +568,7 @@ export class DevelopmentSupervisor {
    * terminal summary. Test generation stays non-fatal: currentPhase remains
    * 'complete' and no errors/validationFeedback/perFileFeedback are written, so
    * it can never feed the validation score or trip the refinement loop — only the
-   * todo/summary reflects the failure.
+   * TodoTracker entry/summary reflects the failure.
    */
   private failTestGeneration(
     todoId: string,

--- a/src/supervisors/development-supervisor.ts
+++ b/src/supervisors/development-supervisor.ts
@@ -915,6 +915,19 @@ Respond with a JSON object:
   /**
    * Write generated files to staging directory
    */
+  /**
+   * F-D: collapse duplicate relativePaths, keeping the LAST writer. Test-gen files
+   * are appended after code-gen, so test-gen wins — preserving the existing
+   * last-writer-wins semantics while ensuring one write per path and a
+   * non-double-counted writtenFiles. After F-A + F-D the paths are disjoint, so
+   * this is a defensive guard.
+   */
+  private dedupeByRelativePath(files: GeneratedFile[]): GeneratedFile[] {
+    const byPath = new Map<string, GeneratedFile>();
+    for (const file of files) byPath.set(file.relativePath, file);
+    return [...byPath.values()];
+  }
+
   async writeToStaging(state: DevelopmentState): Promise<{
     stagingPath: string;
     writtenFiles: string[];
@@ -931,7 +944,7 @@ Respond with a JSON object:
       allFiles.push(...state.testGeneration.files);
     }
 
-    const writtenFiles = await writeToStaging(allFiles, stagingPath);
+    const writtenFiles = await writeToStaging(this.dedupeByRelativePath(allFiles), stagingPath);
 
     console.log(`[Development Supervisor] Written ${writtenFiles.length} files to staging: ${stagingPath}`);
 
@@ -952,7 +965,7 @@ Respond with a JSON object:
       allFiles.push(...state.testGeneration.files);
     }
 
-    const writtenFiles = await writeToChtCore(allFiles, chtCorePath);
+    const writtenFiles = await writeToChtCore(this.dedupeByRelativePath(allFiles), chtCorePath);
 
     console.log(`[Development Supervisor] Written ${writtenFiles.length} files to ${chtCorePath}`);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -542,6 +542,34 @@ export interface CodeGenerationResult {
 }
 
 /**
+ * One requirement mapped to the test scenarios that cover it. Mirrors the
+ * test-gen layer's TestScenario shape but declared here to keep `src/types`
+ * free of any import from `src/layers/*` (which would close a dependency cycle).
+ */
+export interface TestScenarioChecklistItem {
+  requirement: string;
+  scenarios: Array<{
+    name: string;
+    type: 'happy-path' | 'error' | 'edge-case' | 'boundary';
+    description: string;
+  }>;
+}
+
+/**
+ * Test Generation result, as consumed by the Development Supervisor. `files`
+ * is the types-local GeneratedFile (same as CodeGenerationResult.files); the
+ * adapter converts the layer's LayerGeneratedFile output to this shape.
+ */
+export interface TestGenerationResult {
+  files: GeneratedFile[];
+  explanation: string;
+  requirementsChecklist: TestScenarioChecklistItem[];
+  warnings?: string[];
+  tokensUsed?: number;
+  modelUsed?: string;
+}
+
+/**
  * Requirement validation status
  */
 export interface RequirementValidation {
@@ -586,6 +614,7 @@ export interface ImplementationValidation {
 export type DevelopmentPhase =
   | 'init'
   | 'code-generation'
+  | 'test-generation'
   | 'validation'
   | 'complete';
 
@@ -604,6 +633,7 @@ export interface DevelopmentState {
   contextAnalysis: ContextAnalysisResult;
   options: DevelopmentOptions;
   codeGeneration?: CodeGenerationResult;
+  testGeneration?: TestGenerationResult;
   validationResult?: ImplementationValidation;
   currentPhase: DevelopmentPhase;
   errors: string[];

--- a/src/workflows/development-workflow.ts
+++ b/src/workflows/development-workflow.ts
@@ -40,6 +40,7 @@ const MAX_DEVELOPMENT_ITERATIONS = 3;
 export const displayDevelopmentResults = (state: DevelopmentState, duration: string): void => {
   displayDevelopmentHeader(state, duration);
   if (state.codeGeneration) displayCodeGenerationResults(state.codeGeneration);
+  if (state.testGeneration) displayTestGenerationResults(state.testGeneration);
   if (state.validationResult) displayValidationResults(state.validationResult);
 };
 
@@ -75,6 +76,33 @@ function displayCodeGenerationResults(codeGen: NonNullable<DevelopmentState['cod
       if (file.description) console.log(`      ${file.description}`);
     });
   }
+  console.log();
+}
+
+function displayTestGenerationResults(testGen: NonNullable<DevelopmentState['testGeneration']>): void {
+  console.log('🧪 TEST GENERATION RESULTS');
+  console.log('─'.repeat(70));
+  console.log(`Generated Files: ${testGen.files.length}`);
+  if (testGen.explanation) {
+    console.log(`\nSummary:`);
+    console.log(`   ${testGen.explanation}`);
+  }
+  if (testGen.files.length > 0) {
+    console.log(`\nGenerated Files:`);
+    testGen.files.forEach((file, i) => {
+      console.log(`   ${i + 1}. ${file.relativePath}`);
+      console.log(`      Type: ${file.type} | Language: ${file.language} | Action: ${file.action}`);
+      if (file.description) console.log(`      ${file.description}`);
+    });
+  }
+  if (testGen.requirementsChecklist.length > 0) {
+    console.log(`\nRequirements Checklist:`);
+    testGen.requirementsChecklist.forEach((item, i) => {
+      const scenarios = item.scenarios.map(s => s.name).join(', ');
+      console.log(`   ${i + 1}. ${item.requirement}: ${scenarios}`);
+    });
+  }
+  printNumberedList('⚠️  Warnings:', testGen.warnings ?? []);
   console.log();
 }
 
@@ -153,6 +181,7 @@ export const humanDevelopmentValidationCheckpoint = async (
 function collectAllGeneratedFiles(state: DevelopmentState): GeneratedFile[] {
   const allFiles: GeneratedFile[] = [];
   if (state.codeGeneration) allFiles.push(...state.codeGeneration.files);
+  if (state.testGeneration) allFiles.push(...state.testGeneration.files);
   return allFiles;
 }
 

--- a/test/agents/code-generation-agent.spec.ts
+++ b/test/agents/code-generation-agent.spec.ts
@@ -166,10 +166,13 @@ describe('CodeGenerationAgent', () => {
 
       const result = await agent.generate(createInput());
 
-      expect(result.files).to.have.length(3);
+      // The code-gen-authored *.spec.ts is filtered (F-D: test-gen owns tests),
+      // leaving the two source files with their inferred metadata.
+      expect(result.files).to.have.length(2);
+      expect(result.files.find(f => f.relativePath.includes('.spec.'))).to.not.exist;
 
       // TypeScript file (new file → create)
-      const tsFile = result.files.find(f => f.relativePath.endsWith('.ts') && !f.relativePath.includes('spec'));
+      const tsFile = result.files.find(f => f.relativePath.endsWith('.ts'));
       expect(tsFile).to.exist;
       expect(tsFile!.language).to.equal('typescript');
       expect(tsFile!.type).to.equal('source');
@@ -180,11 +183,31 @@ describe('CodeGenerationAgent', () => {
       const jsFile = result.files.find(f => f.relativePath.endsWith('.js'));
       expect(jsFile).to.exist;
       expect(jsFile!.language).to.equal('javascript');
+    });
 
-      // Test file
-      const testFile = result.files.find(f => f.relativePath.includes('spec'));
-      expect(testFile).to.exist;
-      expect(testFile!.type).to.equal('test');
+    it('filters code-gen-authored *.spec.*/*.test.* files but keeps look-alikes (F-D)', async () => {
+      const moduleOutput: CodeGenModuleOutput = {
+        files: [
+          { path: 'api/src/services/messaging.js', content: 'module.exports = {};', purpose: 'Source' },
+          { path: 'api/tests/messaging.spec.js', content: 'describe("m", () => {});', purpose: 'Code-gen test' },
+          { path: 'webapp/src/foo.test.ts', content: 'describe("f", () => {});', purpose: 'Code-gen test' },
+          { path: 'api/src/manifest.js', content: 'module.exports = [];', purpose: 'Manifest (not a test)' },
+          { path: 'api/src/latest.js', content: 'module.exports = 1;', purpose: 'latest (not a test)' },
+        ],
+        explanation: 'Generated 5 files',
+      };
+      generateStub.resolves(moduleOutput);
+
+      const agent = new CodeGenerationAgent({ llmProvider: mockProvider, codeGenRegistry: mockRegistry });
+      const result = await agent.generate(createInput());
+
+      const paths = result.files.map(f => f.relativePath);
+      expect(paths).to.not.include('api/tests/messaging.spec.js');
+      expect(paths).to.not.include('webapp/src/foo.test.ts');
+      // Anchored regex must NOT drop these look-alikes:
+      expect(paths).to.include('api/src/manifest.js');
+      expect(paths).to.include('api/src/latest.js');
+      expect(paths).to.include('api/src/services/messaging.js');
     });
 
     it('should handle empty purpose by mapping to empty description', async () => {
@@ -406,10 +429,12 @@ describe('CodeGenerationAgent', () => {
     });
 
     it('should increase confidence for files with tests', async () => {
+      // A test-support file (fixture/helper), NOT a *.spec.*/*.test.* — F-D keeps
+      // those (code-gen may author fixtures) and inferFileType still types it 'test'.
       const moduleOutput: CodeGenModuleOutput = {
         files: [
           { path: 'src/service.ts', content: 'export class Service {}', purpose: 'Service' },
-          { path: 'test/service.spec.ts', content: 'describe("Service", () => {});', purpose: 'Tests' },
+          { path: 'test/fixtures/service-mock.ts', content: 'export const mock = {};', purpose: 'Test fixture' },
         ],
         explanation: 'Generated',
       };
@@ -504,7 +529,7 @@ describe('CodeGenerationAgent', () => {
       const moduleOutput: CodeGenModuleOutput = {
         files: [
           { path: 'src/service.ts', content: 'export class Service {}', purpose: 'Service' },
-          { path: 'test/service.spec.ts', content: 'describe("test", () => {});', purpose: 'Tests' },
+          { path: 'test/fixtures/service-mock.ts', content: 'export const mock = {};', purpose: 'Test fixture' },
         ],
         explanation: 'Generated',
       };

--- a/test/agents/test-generation-agent.spec.ts
+++ b/test/agents/test-generation-agent.spec.ts
@@ -1,0 +1,360 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  buildTestGenModuleInput,
+  handleTestGenRollbackOutcome,
+  TestGenerationAgent,
+  TestGenerationInput,
+} from '../../src/agents/test-generation-agent';
+import { CodeGenerationResult, GeneratedFile } from '../../src/types';
+import { TestGenModuleRegistry } from '../../src/layers/test-gen/registry';
+import { TestGenModule, TestGenModuleOutput } from '../../src/layers/test-gen/interface';
+import { LLMProvider, LLMResponse, LLMMessage, InvokeOptions } from '../../src/llm';
+
+const mkFile = (relativePath: string): GeneratedFile => ({
+  relativePath,
+  content: `// ${relativePath}\n`,
+  language: 'typescript',
+  type: 'source',
+  description: 'x',
+  action: 'create',
+});
+
+const mkCodeGen = (files: GeneratedFile[]): CodeGenerationResult => ({
+  files,
+  summary: '',
+  implementedRequirements: [],
+  pendingRequirements: [],
+  notes: [],
+  confidence: 0.9,
+});
+
+const baseInput = (overrides: Partial<TestGenerationInput> = {}): TestGenerationInput => ({
+  issue: {
+    issue: {
+      title: 'List numbering',
+      type: 'feature',
+      priority: 'medium',
+      description: 'd',
+      technical_context: { domain: 'contacts', components: [] },
+      requirements: ['r1'],
+      acceptance_criteria: ['a1'],
+      constraints: [],
+    },
+  },
+  researchFindings: {
+    documentationReferences: [],
+    relevantExamples: [],
+    suggestedApproaches: [],
+    relatedDomains: [],
+    confidence: 0.5,
+    source: 'local-docs',
+  },
+  orchestrationPlan: {
+    summary: '',
+    keyFindings: [],
+    recommendedApproach: '',
+    estimatedComplexity: 'medium',
+    phases: [],
+    riskFactors: [],
+    estimatedEffort: '',
+  },
+  codeGeneration: mkCodeGen([mkFile('src/a.ts')]),
+  chtCorePath: '/tmp/cht-core',
+  ...overrides,
+});
+
+describe('buildTestGenModuleInput', () => {
+  it('maps every field to the TestGenModuleInput shape', () => {
+    const input = baseInput();
+    const out = buildTestGenModuleInput(input);
+
+    expect(out.ticket).to.equal(input.issue);
+    expect(out.researchFindings).to.equal(input.researchFindings);
+    expect(out.orchestrationPlan).to.equal(input.orchestrationPlan);
+    expect(out.targetDirectory).to.equal('/tmp/cht-core');
+  });
+
+  it('passes generatedCode through unchanged (no conversion on the way in)', () => {
+    const files = [mkFile('src/a.ts'), mkFile('src/b.ts')];
+    const out = buildTestGenModuleInput(baseInput({ codeGeneration: mkCodeGen(files) }));
+
+    expect(out.generatedCode).to.equal(files);
+  });
+
+  it("defaults testTypes to ['unit'] when absent", () => {
+    expect(buildTestGenModuleInput(baseInput()).testTypes).to.deep.equal(['unit']);
+  });
+
+  it('respects an explicit testTypes value', () => {
+    const out = buildTestGenModuleInput(baseInput({ testTypes: ['integration', 'e2e'] }));
+    expect(out.testTypes).to.deep.equal(['integration', 'e2e']);
+  });
+
+  it('builds an external feedback contextFile only when additionalContext is set', () => {
+    expect(buildTestGenModuleInput(baseInput()).contextFiles).to.deep.equal([]);
+
+    const out = buildTestGenModuleInput(baseInput({ additionalContext: 'fix the off-by-one' }));
+    expect(out.contextFiles).to.have.length(1);
+    expect(out.contextFiles[0]).to.deep.equal({
+      path: 'feedback/additional-context.md',
+      content: 'fix the off-by-one',
+      source: 'external',
+    });
+  });
+
+  it('binds readFile/listDirectory as closures over chtCorePath', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-adapter-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'hello.ts'), 'export const x = 1;\n', 'utf-8');
+      const out = buildTestGenModuleInput(baseInput({ chtCorePath: dir }));
+
+      expect(out.readFile).to.be.a('function');
+      expect(out.listDirectory).to.be.a('function');
+      expect(await out.readFile?.('hello.ts')).to.equal('export const x = 1;\n');
+      expect(await out.readFile?.('nope.ts')).to.equal(null);
+      expect(await out.listDirectory?.('.')).to.include('hello.ts');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+const cannedOutput: TestGenModuleOutput = {
+  files: [
+    { path: 'tests/unit/a.spec.ts', content: '// spec\n', purpose: 'unit tests for a' },
+    { path: 'tests/fixtures/data.json', content: '{}\n' },
+  ],
+  explanation: 'generated 2 test files',
+  tokensUsed: 321,
+  modelUsed: 'fake-model',
+  requirementsChecklist: [
+    { requirement: 'r1', scenarios: [{ name: 'covers r1', type: 'happy-path', description: 'd' }] },
+  ],
+  warnings: ['heads up'],
+};
+
+describe('TestGenerationAgent', () => {
+  let registry: TestGenModuleRegistry;
+  let generateStub: sinon.SinonStub;
+  let agent: TestGenerationAgent;
+
+  const mockProvider: LLMProvider = {
+    providerType: 'anthropic',
+    modelName: 'test-model',
+    honorsCustomTools: true,
+    async invoke(): Promise<LLMResponse> {
+      return { content: '', model: 'test-model' };
+    },
+    async invokeWithMessages(_messages: LLMMessage[], _options?: InvokeOptions): Promise<LLMResponse> {
+      return { content: '', model: 'test-model' };
+    },
+    async invokeForJSON<T>(): Promise<T> {
+      return {} as T;
+    },
+  };
+
+  beforeEach(() => {
+    registry = new TestGenModuleRegistry();
+    generateStub = sinon.stub().resolves(cannedOutput);
+    const fakeModule: TestGenModule = {
+      name: 'claude-api',
+      version: '0.0.0-test',
+      generate: generateStub,
+    };
+    sinon.stub(registry, 'getActiveModule').returns(fakeModule);
+    agent = new TestGenerationAgent({ llmProvider: mockProvider, testGenRegistry: registry });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('converts module files to types-local GeneratedFile (type=test, action=create)', async () => {
+    const result = await agent.generate(baseInput());
+
+    expect(result.files).to.have.length(2);
+    expect(result.files[0]).to.deep.equal({
+      relativePath: 'tests/unit/a.spec.ts',
+      content: '// spec\n',
+      language: 'typescript',
+      type: 'test',
+      description: 'unit tests for a',
+      action: 'create',
+    });
+  });
+
+  it('defaults description to "" and infers language from the path extension', async () => {
+    const result = await agent.generate(baseInput());
+
+    expect(result.files[1]).to.deep.equal({
+      relativePath: 'tests/fixtures/data.json',
+      content: '{}\n',
+      language: 'json',
+      type: 'test',
+      description: '',
+      action: 'create',
+    });
+  });
+
+  it('passes the requirementsChecklist through unchanged', async () => {
+    const result = await agent.generate(baseInput());
+    expect(result.requirementsChecklist).to.deep.equal(cannedOutput.requirementsChecklist);
+  });
+
+  it('maps explanation, warnings, tokensUsed and modelUsed from the module output', async () => {
+    const result = await agent.generate(baseInput());
+
+    expect(result.explanation).to.equal('generated 2 test files');
+    expect(result.warnings).to.deep.equal(['heads up']);
+    expect(result.tokensUsed).to.equal(321);
+    expect(result.modelUsed).to.equal('fake-model');
+  });
+
+  it('builds the module input via buildTestGenModuleInput', async () => {
+    const input = baseInput();
+    await agent.generate(input);
+
+    expect(generateStub.calledOnce).to.equal(true);
+    const moduleInput = generateStub.firstCall.args[0];
+    expect(moduleInput.ticket).to.equal(input.issue);
+    expect(moduleInput.generatedCode).to.equal(input.codeGeneration.files);
+    expect(moduleInput.testTypes).to.deep.equal(['unit']);
+    expect(moduleInput.targetDirectory).to.equal('/tmp/cht-core');
+  });
+});
+
+const cliProvider = (): LLMProvider => ({
+  providerType: 'anthropic',
+  modelName: 'cli',
+  honorsCustomTools: false,
+  async invoke(): Promise<LLMResponse> {
+    return { content: '', model: 'cli' };
+  },
+  async invokeWithMessages(): Promise<LLMResponse> {
+    return { content: '', model: 'cli' };
+  },
+  async invokeForJSON<T>(): Promise<T> {
+    return {} as T;
+  },
+});
+
+const registryReturning = (module: TestGenModule): TestGenModuleRegistry => {
+  const registry = new TestGenModuleRegistry();
+  sinon.stub(registry, 'getActiveModule').returns(module);
+  return registry;
+};
+
+describe('TestGenerationAgent containment (iter8 Fix 2a)', () => {
+  let repo: string;
+  const git = (args: string[]): void => {
+    execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+  };
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-contain-'));
+    git(['init', '-q']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# repo\n', 'utf-8');
+    git(['add', '-A']);
+    git(['commit', '-q', '-m', 'init']);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('rolls back an out-of-band write while preserving the in-memory result', async () => {
+    const strayModule: TestGenModule = {
+      name: 'claude-api',
+      version: '0.0.0-test',
+      generate: async (moduleInput) => {
+        // Simulate an uncontained subprocess write into the cht-core tree.
+        fs.writeFileSync(path.join(moduleInput.targetDirectory, 'stray.spec.js'), '// leaked\n', 'utf-8');
+        return {
+          files: [{ path: 'tests/unit/legit.spec.ts', content: '// legit\n', purpose: 'legit' }],
+          explanation: 'ok',
+          requirementsChecklist: [],
+        };
+      },
+    };
+    const agent = new TestGenerationAgent({
+      llmProvider: cliProvider(),
+      testGenRegistry: registryReturning(strayModule),
+    });
+
+    const result = await agent.generate(baseInput({ chtCorePath: repo }));
+
+    // The out-of-band write is reverted: working tree clean, stray file gone.
+    const status = execFileSync('git', ['status', '--porcelain'], { cwd: repo, encoding: 'utf-8' });
+    expect(status.trim(), 'working tree must be clean after rollback').to.equal('');
+    expect(fs.existsSync(path.join(repo, 'stray.spec.js')), 'stray file must be removed').to.equal(false);
+
+    // The legitimate in-memory output is preserved (captured before rollback).
+    expect(result.files).to.have.length(1);
+    expect(result.files[0].relativePath).to.equal('tests/unit/legit.spec.ts');
+    expect(result.files[0].type).to.equal('test');
+  });
+
+  it('proceeds without containment when chtCorePath is not a git repo', async () => {
+    const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-nongit-'));
+    try {
+      const module: TestGenModule = {
+        name: 'claude-api',
+        version: '0.0.0-test',
+        generate: async () => ({
+          files: [{ path: 'tests/unit/legit.spec.ts', content: '// legit\n' }],
+          explanation: 'ok',
+          requirementsChecklist: [],
+        }),
+      };
+      const agent = new TestGenerationAgent({
+        llmProvider: cliProvider(),
+        testGenRegistry: registryReturning(module),
+      });
+
+      // Snapshot fails on a non-git path; generation still returns its output.
+      const result = await agent.generate(baseInput({ chtCorePath: nonGit }));
+      expect(result.files).to.have.length(1);
+    } finally {
+      fs.rmSync(nonGit, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('handleTestGenRollbackOutcome (iter8 polish)', () => {
+  beforeEach(() => {
+    sinon.stub(console, 'error');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('throws on a fatal reset failure, surfacing the joined errors and the recovery hint', () => {
+    const rollback = { reset: 'failed' as const, clean: 'ok' as const, stashPop: 'skipped' as const, errors: ['e1', 'e2'] };
+    expect(() => handleTestGenRollbackOutcome(rollback)).to.throw(/e1; e2/);
+    expect(() => handleTestGenRollbackOutcome(rollback)).to.throw(/Inspect the cht-core working tree/);
+  });
+
+  it('does not throw on a clean failure when reset succeeded (warn-only)', () => {
+    const rollback = { reset: 'ok' as const, clean: 'failed' as const, stashPop: 'skipped' as const, errors: ['clean failed'] };
+    expect(() => handleTestGenRollbackOutcome(rollback)).to.not.throw();
+  });
+
+  it('does not throw on a stashPop failure when reset succeeded (warn-only)', () => {
+    const rollback = { reset: 'ok' as const, clean: 'ok' as const, stashPop: 'failed' as const, errors: ['stash pop failed'] };
+    expect(() => handleTestGenRollbackOutcome(rollback)).to.not.throw();
+  });
+
+  it('does not throw when everything succeeded', () => {
+    const rollback = { reset: 'ok' as const, clean: 'ok' as const, stashPop: 'ok' as const, errors: [] };
+    expect(() => handleTestGenRollbackOutcome(rollback)).to.not.throw();
+  });
+});

--- a/test/agents/test-generation-agent.spec.ts
+++ b/test/agents/test-generation-agent.spec.ts
@@ -103,7 +103,7 @@ describe('buildTestGenModuleInput', () => {
     // No test-gen module reads contextFiles, so additionalContext is threaded onto
     // `additionalContext` (the plan-prompt feedback branch) and contextFiles stays [].
     expect(buildTestGenModuleInput(baseInput()).contextFiles).to.deep.equal([]);
-    expect(buildTestGenModuleInput(baseInput()).additionalContext).to.equal(undefined);
+    expect(buildTestGenModuleInput(baseInput()).additionalContext).to.be.undefined;
 
     const out = buildTestGenModuleInput(baseInput({ additionalContext: 'fix the off-by-one' }));
     expect(out.contextFiles).to.deep.equal([]);
@@ -125,7 +125,7 @@ describe('buildTestGenModuleInput', () => {
       expect(out.readFile).to.be.a('function');
       expect(out.listDirectory).to.be.a('function');
       expect(await out.readFile?.('hello.ts')).to.equal('export const x = 1;\n');
-      expect(await out.readFile?.('nope.ts')).to.equal(null);
+      expect(await out.readFile?.('nope.ts')).to.be.null;
       expect(await out.listDirectory?.('.')).to.include('hello.ts');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/test/agents/test-generation-agent.spec.ts
+++ b/test/agents/test-generation-agent.spec.ts
@@ -77,6 +77,10 @@ describe('buildTestGenModuleInput', () => {
     expect(out.researchFindings).to.equal(input.researchFindings);
     expect(out.orchestrationPlan).to.equal(input.orchestrationPlan);
     expect(out.targetDirectory).to.equal('/tmp/cht-core');
+    // additionalContext / existingTestExamples forward through on the fields the
+    // module actually reads (M6), not into the dead contextFiles surface.
+    expect(out.additionalContext).to.equal(input.additionalContext);
+    expect(out.existingTestExamples).to.equal(input.existingTestExamples);
   });
 
   it('passes generatedCode through unchanged (no conversion on the way in)', () => {
@@ -95,16 +99,21 @@ describe('buildTestGenModuleInput', () => {
     expect(out.testTypes).to.deep.equal(['integration', 'e2e']);
   });
 
-  it('builds an external feedback contextFile only when additionalContext is set', () => {
+  it('forwards additionalContext on the field the module reads, not into contextFiles (M6)', () => {
+    // No test-gen module reads contextFiles, so additionalContext is threaded onto
+    // `additionalContext` (the plan-prompt feedback branch) and contextFiles stays [].
     expect(buildTestGenModuleInput(baseInput()).contextFiles).to.deep.equal([]);
+    expect(buildTestGenModuleInput(baseInput()).additionalContext).to.equal(undefined);
 
     const out = buildTestGenModuleInput(baseInput({ additionalContext: 'fix the off-by-one' }));
-    expect(out.contextFiles).to.have.length(1);
-    expect(out.contextFiles[0]).to.deep.equal({
-      path: 'feedback/additional-context.md',
-      content: 'fix the off-by-one',
-      source: 'external',
-    });
+    expect(out.contextFiles).to.deep.equal([]);
+    expect(out.additionalContext).to.equal('fix the off-by-one');
+  });
+
+  it('forwards existingTestExamples when pre-seeded on the input (M6)', () => {
+    const examples = [{ path: 'src/a.spec.ts', content: 'describe("a", () => {});' }];
+    const out = buildTestGenModuleInput(baseInput({ existingTestExamples: examples }));
+    expect(out.existingTestExamples).to.equal(examples);
   });
 
   it('binds readFile/listDirectory as closures over chtCorePath', async () => {
@@ -225,6 +234,28 @@ describe('TestGenerationAgent', () => {
     expect(moduleInput.generatedCode).to.equal(input.codeGeneration.files);
     expect(moduleInput.testTypes).to.deep.equal(['unit']);
     expect(moduleInput.targetDirectory).to.equal('/tmp/cht-core');
+  });
+
+  it('populates existingTestExamples by globbing nearby *.spec.* from cht-core (M6)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-examples-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src', 'foo.ts'), 'export const foo = () => 1;');
+      fs.writeFileSync(
+        path.join(dir, 'src', 'foo.spec.ts'),
+        "describe('foo', () => { it('works', () => {}); });",
+      );
+
+      const input = baseInput({ chtCorePath: dir, codeGeneration: mkCodeGen([mkFile('src/foo.ts')]) });
+      await agent.generate(input);
+
+      const moduleInput = generateStub.firstCall.args[0];
+      expect(moduleInput.existingTestExamples).to.have.length(1);
+      expect(moduleInput.existingTestExamples[0].path).to.equal('src/foo.spec.ts');
+      expect(moduleInput.existingTestExamples[0].content).to.include("describe('foo'");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/fixtures/test-gen/semantic-gate/README.md
+++ b/test/fixtures/test-gen/semantic-gate/README.md
@@ -1,0 +1,66 @@
+# Semantic-gate planted-bug fixtures
+
+These fixtures back `test/layers/test-gen/semantic-correctness-gate.spec.ts`, which
+proves the test-gen layer's generated tests actually catch bugs (HARNESS section 8.3):
+the layer's real `generate()` (with a stubbed LLM) emits a test that **fails** against
+buggy source and **passes** against fixed source.
+
+## The planted bug
+
+`source.fixed.ts` mirrors the live `formatListForPrompt` in
+`src/utils/domain-inference.ts`. Items are 1-indexed:
+
+```
+formatListForPrompt(['apple', 'banana'])  ->  "1. apple\n2. banana"
+```
+
+`source.buggy.ts` is a deliberate off-by-one mutation (`${i}` instead of `${i + 1}`):
+
+```
+formatListForPrompt(['apple', 'banana'])  ->  "0. apple\n1. banana"
+```
+
+`source.fixed.ts` mirrors the live source by hand. It is **not** auto-synced: if
+`domain-inference.ts` changes, this fixture does not follow. The fixture is a frozen,
+self-contained reference for the gate, not an import of production code.
+
+## tsconfig.json
+
+The inner mocha run (spawned by the spec) executes the emitted test under
+`ts-node/register`. This `tsconfig.json` is copied into the per-run temp dir and
+pointed at via `TS_NODE_PROJECT`; it resolves chai through the temp dir's
+`node_modules` symlink (CommonJS, `esModuleInterop`).
+
+## Files written at runtime, never committed
+
+The spec writes `source.ts` (a copy of the chosen variant) and `gen.spec.ts` (the
+module's emitted test) into a fresh `mkdtemp` temp dir per run, then removes the dir.
+Only `source.fixed.ts`, `source.buggy.ts`, `tsconfig.json`, and this README are
+committed.
+
+## Manual repro
+
+```
+tmp=$(mktemp -d)
+ln -s "$PWD/node_modules" "$tmp/node_modules"
+cp test/fixtures/test-gen/semantic-gate/tsconfig.json "$tmp/tsconfig.json"
+cp test/fixtures/test-gen/semantic-gate/source.buggy.ts "$tmp/source.ts"   # or source.fixed.ts
+cat > "$tmp/gen.spec.ts" <<'EOF'
+import { expect } from 'chai';
+import { formatListForPrompt } from './source';
+describe('formatListForPrompt numbering', () => {
+  it('numbers items starting at 1', () => {
+    const out = formatListForPrompt(['apple', 'banana']);
+    expect(out).to.include('1. apple');
+    expect(out).to.not.include('0. apple');
+  });
+});
+EOF
+TS_NODE_PROJECT="$tmp/tsconfig.json" node_modules/.bin/mocha \
+  --no-config --require ts-node/register --extension ts "$tmp/gen.spec.ts"
+echo "exit: $?"   # buggy -> nonzero, fixed -> 0
+rm -rf "$tmp"
+```
+
+`--no-config` is required: without it the repo `.mocharc.json` injects its
+`test/**/*.spec.ts` glob and pulls the whole suite into the child process.

--- a/test/fixtures/test-gen/semantic-gate/source.buggy.ts
+++ b/test/fixtures/test-gen/semantic-gate/source.buggy.ts
@@ -1,0 +1,14 @@
+// Buggy variant: a deliberate off-by-one mutation of source.fixed.ts.
+// Items are 0-indexed (`${i}`) instead of 1-indexed. For ['apple','banana']
+// this emits "0. apple\n1. banana" instead of "1. apple\n2. banana".
+// A generated test that genuinely probes the numbering MUST fail here.
+// See README.md in this directory.
+export const formatListForPrompt = (
+  items: string[],
+  emptyMessage: string = 'None provided',
+): string => {
+  if (!items || items.length === 0) {
+    return emptyMessage;
+  }
+  return items.map((item, i) => `${i}. ${item}`).join('\n');
+};

--- a/test/fixtures/test-gen/semantic-gate/source.fixed.ts
+++ b/test/fixtures/test-gen/semantic-gate/source.fixed.ts
@@ -1,0 +1,12 @@
+// Fixed variant: mirrors the live formatListForPrompt in
+// src/utils/domain-inference.ts. Items are 1-indexed (`${i + 1}`).
+// See README.md in this directory.
+export const formatListForPrompt = (
+  items: string[],
+  emptyMessage: string = 'None provided',
+): string => {
+  if (!items || items.length === 0) {
+    return emptyMessage;
+  }
+  return items.map((item, i) => `${i + 1}. ${item}`).join('\n');
+};

--- a/test/fixtures/test-gen/semantic-gate/tsconfig.json
+++ b/test/fixtures/test-gen/semantic-gate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false
+  }
+}

--- a/test/layers/code-gen/lib/output-parsing.spec.ts
+++ b/test/layers/code-gen/lib/output-parsing.spec.ts
@@ -238,3 +238,18 @@ describe('parseFirstGenFileContent member-expression guard (MG-3)', () => {
     expect(out).to.include('const x = 1');
   });
 });
+
+describe('parseFirstGenFileContent deferred leak shapes (NEW-2, NEW-3)', () => {
+  // Deferred to a future boundary-hardening iteration (see v15 plan "Residuals").
+  // Both fail SAFE (leak -> node --check fails -> the parse gate retries). Kept as
+  // discriminating placeholders so the follow-up fix has a target.
+  it.skip('NEW-2: strips a lowercase-keyword-prefix preamble ("import the chai helpers referenced below:")', () => {
+    const raw = "import the chai helpers referenced below:\nimport { expect } from 'chai';\ndescribe('t', () => {});";
+    expect(parseFirstGenFileContent(raw)).to.equal("import { expect } from 'chai';\ndescribe('t', () => {});\n");
+  });
+
+  it.skip('NEW-3: removes interior/sandwiched prose between two code sections', () => {
+    const raw = 'const a = 1;\nThis explains the next part.\nconst b = 2;';
+    expect(parseFirstGenFileContent(raw)).to.equal('const a = 1;\nconst b = 2;\n');
+  });
+});

--- a/test/layers/code-gen/lib/output-parsing.spec.ts
+++ b/test/layers/code-gen/lib/output-parsing.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { parseSingleFileContent, applySearchReplace, PROSE_PATTERN } from '../../../../src/layers/code-gen/lib/output-parsing';
+import {
+  parseSingleFileContent,
+  parseFirstGenFileContent,
+  applySearchReplace,
+  PROSE_PATTERN,
+} from '../../../../src/layers/code-gen/lib/output-parsing';
 
 describe('parseSingleFileContent', () => {
   describe('trailing newline preservation (C1)', () => {
@@ -77,6 +82,54 @@ describe('PROSE_PATTERN', () => {
     const pathological = 'Ab' + ' '.repeat(40000);
     const start = process.hrtime.bigint();
     PROSE_PATTERN.test(pathological);
+    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+    expect(elapsedMs).to.be.below(100);
+  });
+});
+
+describe('parseFirstGenFileContent (F-B first-gen hardening)', () => {
+  it('strips a leading preamble, a wrapping fence, and trailing prose (the CLI leak shape)', () => {
+    const raw =
+      "Here is the test file you asked for:\n" +
+      "```typescript\n" +
+      "import { expect } from 'chai';\n" +
+      "describe('x', () => {});\n" +
+      "```\n" +
+      "Let me know if you need changes.";
+    expect(parseFirstGenFileContent(raw)).to.equal(
+      "import { expect } from 'chai';\ndescribe('x', () => {});\n",
+    );
+  });
+
+  it('strips a broadened lowercase preamble but leaves real code that starts lowercase', () => {
+    expect(parseFirstGenFileContent("here's the spec:\nimport x from 'y';\ndescribe('a', () => {});"))
+      .to.equal("import x from 'y';\ndescribe('a', () => {});\n");
+    // A real code first line (not a keyword, lowercase) must NOT be treated as preamble:
+    expect(parseFirstGenFileContent('foo.bar();\nconst x = 1;')).to.equal('foo.bar();\nconst x = 1;\n');
+  });
+
+  it('does NOT slice out an interior fence inside real code (template literal)', () => {
+    const raw =
+      "import { expect } from 'chai';\n" +
+      "const md = `\n```js\ncode\n```\n`;\n" +
+      "describe('z', () => {});";
+    const out = parseFirstGenFileContent(raw);
+    expect(out).to.include('```js'); // interior fence preserved (code precedes it)
+    expect(out).to.include("import { expect } from 'chai'");
+  });
+
+  it('is confined to first-gen: parseSingleFileContent (continuation) leaves what the first-gen parser strips', () => {
+    const chunk = 'following the pattern above\nconst x = 1;';
+    // first-gen: broadened preamble strip removes the prose opener
+    expect(parseFirstGenFileContent(chunk)).to.equal('const x = 1;\n');
+    // continuation parser (narrow) is byte-identical to before — the resumed line survives
+    expect(parseSingleFileContent(chunk)).to.equal('following the pattern above\nconst x = 1;\n');
+  });
+
+  it('runs in linear time on a large never-closing fence (S8786)', () => {
+    const pathological = '```typescript\n' + 'x'.repeat(200000);
+    const start = process.hrtime.bigint();
+    parseFirstGenFileContent(pathological);
     const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
     expect(elapsedMs).to.be.below(100);
   });

--- a/test/layers/code-gen/lib/output-parsing.spec.ts
+++ b/test/layers/code-gen/lib/output-parsing.spec.ts
@@ -213,3 +213,28 @@ describe('parseFirstGenFileContent trailing-prose strip (MG-1)', () => {
   it('leaves a whole normal spec with no trailing prose', () =>
     unchanged("import { expect } from 'chai';\ndescribe('t', () => {\n  it('w', () => { expect(1).to.equal(1); });\n});"));
 });
+
+describe('parseFirstGenFileContent member-expression guard (MG-3)', () => {
+  it('does NOT slice an interior fence when the first line is a member-expression assignment', () => {
+    // v14 mistook the interior ```bash for a wrapper and discarded the body — and
+    // its truncated output passed node --check (silent loss). The guard preserves it.
+    const raw =
+      'messages.intro = `\n' +
+      '```bash\n' +
+      'echo hi\n' +
+      '```\n' +
+      '`;\n' +
+      "describe('t', () => {});";
+    const out = parseFirstGenFileContent(raw);
+    expect(out).to.include('messages.intro'); // body NOT discarded
+    expect(out).to.include("describe('t', () => {})");
+    expect(out).to.include('```bash'); // interior fence preserved
+  });
+
+  it('also guards a plain (non-member) assignment of a fence-containing template', () => {
+    const raw = 'banner = `\n```js\ncode\n```\n`;\nconst x = 1;';
+    const out = parseFirstGenFileContent(raw);
+    expect(out).to.include('banner =');
+    expect(out).to.include('const x = 1');
+  });
+});

--- a/test/layers/code-gen/lib/output-parsing.spec.ts
+++ b/test/layers/code-gen/lib/output-parsing.spec.ts
@@ -134,3 +134,39 @@ describe('parseFirstGenFileContent (F-B first-gen hardening)', () => {
     expect(elapsedMs).to.be.below(100);
   });
 });
+
+describe('parseFirstGenFileContent fence close selection (MG-2, NEW-1)', () => {
+  it('selects the FIRST fence close so a trailing fenced note is not swallowed (MG-2)', () => {
+    const raw =
+      "```typescript\n" +
+      "describe('t', () => {});\n" +
+      "```\n" +
+      "Note, run it with:\n" +
+      "```bash\n" +
+      "npm test\n" +
+      "```";
+    expect(parseFirstGenFileContent(raw)).to.equal("describe('t', () => {});\n");
+  });
+
+  it('extracts only the first fenced block when two blocks are present', () => {
+    const raw = "```js\nconst a = 1;\n```\n```js\nconst b = 2;\n```";
+    expect(parseFirstGenFileContent(raw)).to.equal('const a = 1;\n');
+  });
+
+  it('accepts a language-tagged close as a fallback when there is no bare close (NEW-1)', () => {
+    const raw = "```typescript\ndescribe('t', () => {});\n```js";
+    expect(parseFirstGenFileContent(raw)).to.equal("describe('t', () => {});\n");
+  });
+
+  it('keeps a nested tagged fence in the body when a real bare close exists (no mis-slice)', () => {
+    // A `` ```js `` appears inside a string in the body; the tagged fallback stays
+    // dormant because a real bare close (the wrapper) exists, so the full body is kept.
+    const raw = "```typescript\nconst snippet = '```js';\ndescribe('t', () => {});\n```";
+    expect(parseFirstGenFileContent(raw)).to.equal("const snippet = '```js';\ndescribe('t', () => {});\n");
+  });
+
+  it('takes everything after the open when the fence is never closed (truncation)', () => {
+    const raw = "```typescript\ndescribe('t', () => {\n  it('w', () => {";
+    expect(parseFirstGenFileContent(raw)).to.equal("describe('t', () => {\n  it('w', () => {\n");
+  });
+});

--- a/test/layers/code-gen/lib/output-parsing.spec.ts
+++ b/test/layers/code-gen/lib/output-parsing.spec.ts
@@ -170,3 +170,46 @@ describe('parseFirstGenFileContent fence close selection (MG-2, NEW-1)', () => {
     expect(parseFirstGenFileContent(raw)).to.equal("describe('t', () => {\n  it('w', () => {\n");
   });
 });
+
+describe('parseFirstGenFileContent trailing-prose strip (MG-1)', () => {
+  // Each fixture is already trimmed, so a byte-unchanged parse returns it + one '\n'.
+  const unchanged = (src: string) => expect(parseFirstGenFileContent(src)).to.equal(src + '\n');
+
+  it('strips unfenced trailing prose (the MG-1 repro) — fails at v14, passes now', () => {
+    const raw =
+      'Here is the test file:\n' +
+      "const { expect } = require('chai');\n" +
+      "describe('t', () => { it('w', () => { expect(1).to.equal(1); }); });\n" +
+      'Let me know if you need any changes.';
+    expect(parseFirstGenFileContent(raw)).to.equal(
+      "const { expect } = require('chai');\n" +
+        "describe('t', () => { it('w', () => { expect(1).to.equal(1); }); });\n",
+    );
+  });
+
+  it('strips a trailing multi-line prose paragraph clean', () => {
+    const raw =
+      "describe('t', () => {\n  it('w', () => {});\n});\n" +
+      'This test verifies the behavior.\n' +
+      'It should be reviewed before merging.';
+    expect(parseFirstGenFileContent(raw)).to.equal("describe('t', () => {\n  it('w', () => {});\n});\n");
+  });
+
+  it('leaves code ending in });', () => unchanged("describe('t', () => {\n  it('w', () => {});\n});"));
+  it('leaves code ending in );', () => unchanged('foo(\n  bar,\n);'));
+  it('leaves code ending in }', () => unchanged('function f() {\n  return 1;\n}'));
+  it('leaves a trailing block-comment close */', () => unchanged('const x = 1;\n/*\n * note\n */'));
+  it('leaves a trailing expect(...) statement', () =>
+    unchanged('const result = 1;\nexpect(result).to.equal(true);'));
+  it('leaves a template literal closing on a prose line', () =>
+    unchanged('const note = `\nPlease review the report.`;'));
+  it('does not strip prose INSIDE an open template literal', () =>
+    unchanged('const banner = `\nWelcome to the app'));
+  it('leaves a capitalized member call that looks like prose', () =>
+    unchanged('Contact.save({ patient_id: id });'));
+  it('leaves module.exports', () => unchanged('module.exports = { foo: 1 };'));
+  it('leaves a trailing line comment', () => unchanged('const x = 1;\n// done'));
+  it('leaves a trailing one-line block comment', () => unchanged('const x = 1;\n/* note */'));
+  it('leaves a whole normal spec with no trailing prose', () =>
+    unchanged("import { expect } from 'chai';\ndescribe('t', () => {\n  it('w', () => { expect(1).to.equal(1); });\n});"));
+});

--- a/test/layers/code-gen/lib/output-parsing.spec.ts
+++ b/test/layers/code-gen/lib/output-parsing.spec.ts
@@ -239,17 +239,6 @@ describe('parseFirstGenFileContent member-expression guard (MG-3)', () => {
   });
 });
 
-describe('parseFirstGenFileContent deferred leak shapes (NEW-2, NEW-3)', () => {
-  // Deferred to a future boundary-hardening iteration (see v15 plan "Residuals").
-  // Both fail SAFE (leak -> node --check fails -> the parse gate retries). Kept as
-  // discriminating placeholders so the follow-up fix has a target.
-  it.skip('NEW-2: strips a lowercase-keyword-prefix preamble ("import the chai helpers referenced below:")', () => {
-    const raw = "import the chai helpers referenced below:\nimport { expect } from 'chai';\ndescribe('t', () => {});";
-    expect(parseFirstGenFileContent(raw)).to.equal("import { expect } from 'chai';\ndescribe('t', () => {});\n");
-  });
-
-  it.skip('NEW-3: removes interior/sandwiched prose between two code sections', () => {
-    const raw = 'const a = 1;\nThis explains the next part.\nconst b = 2;';
-    expect(parseFirstGenFileContent(raw)).to.equal('const a = 1;\nconst b = 2;\n');
-  });
-});
+// The deferred first-gen leak shapes NEW-2 (lowercase code-keyword-prefix preamble)
+// and NEW-3 (interior/sandwiched prose) are tracked in the parser boundary-hardening
+// follow-up (medic/cht-agent#139) rather than as skipped tests here.

--- a/test/layers/test-gen/claude-api-module.spec.ts
+++ b/test/layers/test-gen/claude-api-module.spec.ts
@@ -1,0 +1,304 @@
+import { expect } from 'chai';
+import { ClaudeApiTestGenModule } from '../../../src/layers/test-gen/modules/claude-api';
+
+describe('ClaudeApiTestGenModule', () => {
+  const module = new ClaudeApiTestGenModule();
+
+  describe('parseTestPlan()', () => {
+    it('should parse a well-formed test plan', () => {
+      const raw = `=== TEST PLAN ===
+1. unit tests/unit/controllers/contacts.spec.js → api/src/controllers/contacts.js - Unit tests for contact search
+2. integration tests/integration/contacts-search.spec.js → api/src/controllers/contacts.js - Integration test with CouchDB
+=== END TEST PLAN ===`;
+
+      const plan = module.parseTestPlan(raw);
+
+      expect(plan).to.have.length(2);
+      expect(plan[0]).to.deep.equal({
+        testType: 'unit',
+        filePath: 'tests/unit/controllers/contacts.spec.js',
+        targetSourceFile: 'api/src/controllers/contacts.js',
+        description: 'Unit tests for contact search',
+      });
+      expect(plan[1].testType).to.equal('integration');
+    });
+
+    it('should handle e2e test type', () => {
+      const raw = `=== TEST PLAN ===
+1. e2e tests/e2e/contacts-workflow.spec.js → webapp/src/ts/modules/contacts/contacts.component.ts - E2E workflow test
+=== END TEST PLAN ===`;
+
+      const plan = module.parseTestPlan(raw);
+
+      expect(plan).to.have.length(1);
+      expect(plan[0].testType).to.equal('e2e');
+    });
+
+    it('should strip backticks from file paths', () => {
+      const raw = `=== TEST PLAN ===
+1. unit \`tests/unit/service.spec.js\` → \`api/src/services/service.js\` - Unit tests
+=== END TEST PLAN ===`;
+
+      const plan = module.parseTestPlan(raw);
+
+      expect(plan).to.have.length(1);
+      expect(plan[0].filePath).to.equal('tests/unit/service.spec.js');
+      expect(plan[0].targetSourceFile).to.equal('api/src/services/service.js');
+    });
+
+    it('should return empty array for unparseable content', () => {
+      const raw = `Here is my plan:\n- Create some tests\n- Run them`;
+
+      const plan = module.parseTestPlan(raw);
+
+      expect(plan).to.deep.equal([]);
+    });
+
+    it('should handle plan without delimiters', () => {
+      const raw = `1. unit tests/unit/auth.spec.js → api/src/auth.js - Auth tests`;
+
+      const plan = module.parseTestPlan(raw);
+
+      expect(plan).to.have.length(1);
+      expect(plan[0].filePath).to.equal('tests/unit/auth.spec.js');
+    });
+
+    it('should handle em dash separator', () => {
+      const raw = `=== TEST PLAN ===
+1. unit tests/unit/contacts.spec.js → api/src/contacts.js — Contact lookup tests
+=== END TEST PLAN ===`;
+
+      const plan = module.parseTestPlan(raw);
+
+      expect(plan).to.have.length(1);
+      expect(plan[0].description).to.equal('Contact lookup tests');
+    });
+  });
+
+  describe('parseRequirementsChecklist()', () => {
+    it('should parse valid JSON checklist', () => {
+      const raw = `{
+        "checklist": [
+          {
+            "requirement": "Search contacts by phone",
+            "scenarios": [
+              {
+                "name": "should find contact by exact phone",
+                "type": "happy-path",
+                "description": "Tests exact phone match"
+              }
+            ]
+          }
+        ]
+      }`;
+
+      const checklist = module.parseRequirementsChecklist(raw);
+
+      expect(checklist).to.have.length(1);
+      expect(checklist[0].requirement).to.equal('Search contacts by phone');
+      expect(checklist[0].scenarios).to.have.length(1);
+      expect(checklist[0].scenarios[0].type).to.equal('happy-path');
+    });
+
+    it('should extract JSON from surrounding text', () => {
+      const raw = `Here is the checklist:\n{"checklist": [{"requirement": "Test req", "scenarios": [{"name": "test", "type": "happy-path", "description": "desc"}]}]}\nDone.`;
+
+      const checklist = module.parseRequirementsChecklist(raw);
+
+      expect(checklist).to.have.length(1);
+    });
+
+    it('should return empty array for invalid JSON', () => {
+      const raw = `This is not JSON at all.`;
+
+      const checklist = module.parseRequirementsChecklist(raw);
+
+      expect(checklist).to.deep.equal([]);
+    });
+
+    it('should return empty array for JSON without checklist field', () => {
+      const raw = `{"data": []}`;
+
+      const checklist = module.parseRequirementsChecklist(raw);
+
+      expect(checklist).to.deep.equal([]);
+    });
+  });
+
+  describe('extractCodeContent()', () => {
+    it('should strip markdown code fences', () => {
+      const raw = '```javascript\nconst x = 1;\n```';
+
+      const content = module.extractCodeContent(raw);
+
+      expect(content).to.equal('const x = 1;');
+    });
+
+    it('should strip leading prose before code', () => {
+      const raw = `Here is the test file:\nimport { expect } from 'chai';\n\ndescribe('test', () => {});`;
+
+      const content = module.extractCodeContent(raw);
+
+      expect(content).to.include("import { expect } from 'chai';");
+      expect(content.indexOf("import { expect }")).to.equal(0);
+    });
+
+    it('should preserve content starting with describe()', () => {
+      const raw = `describe('MyService', () => {\n  it('works', () => {});\n});`;
+
+      const content = module.extractCodeContent(raw);
+
+      expect(content).to.equal(raw);
+    });
+
+    it('should preserve content starting with require()', () => {
+      const raw = `require('chai');\nconst x = 1;`;
+
+      // extractCodeContent starts from the first code-like line
+      const content = module.extractCodeContent(raw);
+
+      expect(content).to.include("require('chai')");
+      expect(content.indexOf("require('chai')")).to.equal(0);
+    });
+
+    it('should handle content starting with comments', () => {
+      const raw = `// Test file for contacts\nimport sinon from 'sinon';`;
+
+      const content = module.extractCodeContent(raw);
+
+      expect(content).to.include('// Test file');
+      expect(content.indexOf('// Test file')).to.equal(0);
+    });
+
+    it('should return trimmed content', () => {
+      const raw = `  \n  const x = 1;\n  `;
+
+      const content = module.extractCodeContent(raw);
+
+      expect(content).to.equal('const x = 1;');
+    });
+  });
+
+  describe('buildTestPlanPrompt()', () => {
+    const baseInput = {
+      ticket: {
+        issue: {
+          title: 'Add contact search filters',
+          type: 'feature' as const,
+          priority: 'medium' as const,
+          description: 'Allow filtering contacts',
+          technical_context: {
+            domain: 'contacts' as const,
+            components: ['api/controllers/contacts'],
+          },
+          requirements: ['Search by phone', 'Search by name'],
+          acceptance_criteria: ['Returns matching contacts'],
+          constraints: [],
+        },
+      },
+      researchFindings: {
+        documentationReferences: [],
+        relevantExamples: [],
+        suggestedApproaches: [],
+        relatedDomains: [],
+        confidence: 0.9,
+        source: 'local-docs' as const,
+      },
+      orchestrationPlan: {
+        summary: 'Add filters',
+        keyFindings: [],
+        proposedApproach: 'Extend API',
+        recommendedApproach: 'Extend the existing contacts API with filter query parameters',
+        estimatedComplexity: 'medium' as const,
+        phases: [{
+          name: 'API',
+          description: 'Add filter params',
+          estimatedComplexity: 'medium' as const,
+          suggestedComponents: ['api/controllers/contacts'],
+          dependencies: [],
+        }],
+        riskFactors: [],
+        estimatedEffort: '2 days',
+      },
+      generatedCode: [{
+        relativePath: 'api/src/controllers/contacts.js',
+        content: 'module.exports = {};',
+        language: 'javascript' as const,
+        type: 'source' as const,
+        description: 'Contacts controller',
+        action: 'modify' as const,
+      }],
+      contextFiles: [],
+      testTypes: ['unit' as const, 'integration' as const],
+      targetDirectory: 'tmp/',
+    };
+
+    it('should include issue details in prompt', () => {
+      const prompt = module.buildTestPlanPrompt(baseInput);
+
+      expect(prompt).to.include('Add contact search filters');
+      expect(prompt).to.include('contacts');
+      expect(prompt).to.include('Search by phone');
+    });
+
+    it('should include source file summary', () => {
+      const prompt = module.buildTestPlanPrompt(baseInput);
+
+      expect(prompt).to.include('api/src/controllers/contacts.js');
+    });
+
+    it('should include requested test types', () => {
+      const prompt = module.buildTestPlanPrompt(baseInput);
+
+      expect(prompt).to.include('unit, integration');
+    });
+
+    it('should include CHT test conventions', () => {
+      const prompt = module.buildTestPlanPrompt(baseInput);
+
+      expect(prompt).to.include('Mocha');
+      expect(prompt).to.include('Chai');
+      expect(prompt).to.include('sinon.restore()');
+    });
+
+    it('should include existing test patterns when provided', () => {
+      const input = {
+        ...baseInput,
+        existingTestExamples: [{
+          path: 'tests/unit/contacts.spec.js',
+          content: 'describe("contacts", () => { it("works", () => {}); });',
+        }],
+      };
+
+      const prompt = module.buildTestPlanPrompt(input);
+
+      expect(prompt).to.include('Existing Test Patterns');
+      expect(prompt).to.include('tests/unit/contacts.spec.js');
+    });
+
+    it('should include feedback when provided', () => {
+      const input = {
+        ...baseInput,
+        additionalContext: 'Previous tests missed error cases',
+      };
+
+      const prompt = module.buildTestPlanPrompt(input);
+
+      expect(prompt).to.include('Previous tests missed error cases');
+    });
+
+    it('should include plan format instructions', () => {
+      const prompt = module.buildTestPlanPrompt(baseInput);
+
+      expect(prompt).to.include('=== TEST PLAN ===');
+      expect(prompt).to.include('=== END TEST PLAN ===');
+    });
+  });
+
+  describe('validate()', () => {
+    it('should return a boolean', async () => {
+      const result = await module.validate?.();
+      expect(typeof result).to.equal('boolean');
+    });
+  });
+});

--- a/test/layers/test-gen/claude-api-module.spec.ts
+++ b/test/layers/test-gen/claude-api-module.spec.ts
@@ -123,6 +123,34 @@ describe('ClaudeApiTestGenModule', () => {
 
       expect(checklist).to.deep.equal([]);
     });
+
+    it('parses valid JSON even when trailing prose contains a brace (M8)', () => {
+      // The old greedy /\{[\s\S]*\}/ anchored to the LAST `}` (the one in "{}"),
+      // over-captured, and JSON.parse threw -> silent []. The balanced scan stops
+      // at the object's own close.
+      const raw = `{"checklist": [{"requirement": "R", "scenarios": [{"name": "n", "type": "happy-path", "description": "d"}]}]}\nNote: use {} for an empty object.`;
+
+      const checklist = module.parseRequirementsChecklist(raw);
+
+      expect(checklist).to.have.length(1);
+      expect(checklist[0].requirement).to.equal('R');
+    });
+
+    it('captures a deeply nested checklist fully, not truncated at the first } (M8)', () => {
+      const raw = `prefix {"checklist": [{"requirement": "R", "scenarios": [{"name": "n", "type": "edge-case", "description": "d"}]}]} suffix`;
+
+      const checklist = module.parseRequirementsChecklist(raw);
+
+      expect(checklist).to.have.length(1);
+      expect(checklist[0].scenarios[0].type).to.equal('edge-case');
+    });
+
+    it('returns [] for a checklist with an invalid scenario type (schema is authoritative, M1)', () => {
+      // Old code fell through to returning the raw (unvalidated) checklist here.
+      const raw = `{"checklist": [{"requirement": "R", "scenarios": [{"name": "n", "type": "not-a-type", "description": "d"}]}]}`;
+
+      expect(module.parseRequirementsChecklist(raw)).to.deep.equal([]);
+    });
   });
 
   describe('extractCodeContent()', () => {

--- a/test/layers/test-gen/claude-api-module.spec.ts
+++ b/test/layers/test-gen/claude-api-module.spec.ts
@@ -153,60 +153,6 @@ describe('ClaudeApiTestGenModule', () => {
     });
   });
 
-  describe('extractCodeContent()', () => {
-    it('should strip markdown code fences', () => {
-      const raw = '```javascript\nconst x = 1;\n```';
-
-      const content = module.extractCodeContent(raw);
-
-      expect(content).to.equal('const x = 1;');
-    });
-
-    it('should strip leading prose before code', () => {
-      const raw = `Here is the test file:\nimport { expect } from 'chai';\n\ndescribe('test', () => {});`;
-
-      const content = module.extractCodeContent(raw);
-
-      expect(content).to.include("import { expect } from 'chai';");
-      expect(content.indexOf("import { expect }")).to.equal(0);
-    });
-
-    it('should preserve content starting with describe()', () => {
-      const raw = `describe('MyService', () => {\n  it('works', () => {});\n});`;
-
-      const content = module.extractCodeContent(raw);
-
-      expect(content).to.equal(raw);
-    });
-
-    it('should preserve content starting with require()', () => {
-      const raw = `require('chai');\nconst x = 1;`;
-
-      // extractCodeContent starts from the first code-like line
-      const content = module.extractCodeContent(raw);
-
-      expect(content).to.include("require('chai')");
-      expect(content.indexOf("require('chai')")).to.equal(0);
-    });
-
-    it('should handle content starting with comments', () => {
-      const raw = `// Test file for contacts\nimport sinon from 'sinon';`;
-
-      const content = module.extractCodeContent(raw);
-
-      expect(content).to.include('// Test file');
-      expect(content.indexOf('// Test file')).to.equal(0);
-    });
-
-    it('should return trimmed content', () => {
-      const raw = `  \n  const x = 1;\n  `;
-
-      const content = module.extractCodeContent(raw);
-
-      expect(content).to.equal('const x = 1;');
-    });
-  });
-
   describe('buildTestPlanPrompt()', () => {
     const baseInput = {
       ticket: {

--- a/test/layers/test-gen/claude-api-module.spec.ts
+++ b/test/layers/test-gen/claude-api-module.spec.ts
@@ -1,5 +1,27 @@
 import { expect } from 'chai';
-import { ClaudeApiTestGenModule } from '../../../src/layers/test-gen/modules/claude-api';
+import { ClaudeApiTestGenModule, siblingSpecPath } from '../../../src/layers/test-gen/modules/claude-api';
+
+describe('siblingSpecPath (F-A)', () => {
+  it('inserts .additional before the .spec segment, same directory', () => {
+    expect(siblingSpecPath('api/tests/messaging.spec.js')).to.equal('api/tests/messaging.additional.spec.js');
+  });
+
+  it('handles .test.<ext> too', () => {
+    expect(siblingSpecPath('webapp/src/foo.test.ts')).to.equal('webapp/src/foo.additional.test.ts');
+  });
+
+  it('bumps a counter when a numbered sibling is requested', () => {
+    expect(siblingSpecPath('a/b/c.spec.js', 2)).to.equal('a/b/c.additional.2.spec.js');
+  });
+
+  it('takes the LAST .spec segment and keeps the directory', () => {
+    expect(siblingSpecPath('a.spec.dir/x.spec.js')).to.equal('a.spec.dir/x.additional.spec.js');
+  });
+
+  it('falls back to inserting before the final extension when no .spec/.test segment', () => {
+    expect(siblingSpecPath('weird/name.js')).to.equal('weird/name.additional.js');
+  });
+});
 
 describe('ClaudeApiTestGenModule', () => {
   const module = new ClaudeApiTestGenModule();

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -1,0 +1,203 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ClaudeApiTestGenModule } from '../../../src/layers/test-gen/modules/claude-api';
+import { TestGenModuleInput } from '../../../src/layers/test-gen/interface';
+import { GeneratedFile } from '../../../src/types';
+import { LLMProvider, LLMResponse, LLMMessage, InvokeOptions } from '../../../src/llm';
+
+/**
+ * Iteration-7 module/provider seam test (manual-run finding A2/A4).
+ *
+ * The whole suite stubs at or above the provider boundary, so nothing else
+ * exercises how the test-gen module's InvokeOptions behave per provider. This
+ * drives ClaudeApiTestGenModule.generate() end to end with a fake LLMProvider
+ * whose invoke records its InvokeOptions. The Phase-2 tool decision is gated on
+ * the provider's honorsCustomTools capability (iter8): false for the CLI.
+ *
+ * The input binds readFile/listDirectory, so buildTestGenTools returns a
+ * non-undefined {tools, toolHandler}. On a provider that does not honor custom
+ * tools, the Phase-2 call must carry disableTools instead (the keystone fix);
+ * a provider that honors them must keep the tools (A8).
+ */
+
+const makeResponse = (content: string, stopReason?: string): LLMResponse => ({
+  content,
+  model: 'test-model',
+  usage: { inputTokens: 100, outputTokens: 100 },
+  stopReason,
+});
+
+// Plan (onCall 0): one valid TEST_PLAN_ITEM_RE line -> single-item plan.
+const PLAN_RESPONSE = makeResponse(
+  `=== TEST PLAN ===
+1. unit gen.spec.ts -> source.ts - Unit tests for formatListForPrompt numbering
+=== END TEST PLAN ===`
+);
+
+// Per-file (onCall 1): minimal content that passes the content assertions
+// (import + describe + it + expect) so it is accepted on the first attempt and
+// the run does not retry, pinning callCount to plan + per-file + checklist.
+const PHASE2_RESPONSE = makeResponse(
+  `import { expect } from 'chai';
+describe('seam', () => {
+  it('passes', () => {
+    expect(1).to.equal(1);
+  });
+});
+`,
+  'end_turn'
+);
+
+// Checklist (onCall 2): valid JSON for RequirementsChecklistSchema.
+const CHECKLIST_RESPONSE = makeResponse('{"checklist": []}');
+
+// Input with readFile/listDirectory bound, so buildTestGenTools is non-undefined.
+const makeToolBoundInput = (): TestGenModuleInput => {
+  const generatedCode: GeneratedFile[] = [
+    {
+      relativePath: 'source.ts',
+      content: 'export const formatListForPrompt = (): string => "";',
+      language: 'typescript',
+      type: 'source',
+      description: 'formatListForPrompt under test',
+      action: 'create',
+    },
+  ];
+  return {
+    ticket: {
+      issue: {
+        title: 'List numbering',
+        type: 'feature',
+        priority: 'medium',
+        description: 'Format a list for prompts with 1-indexed numbering.',
+        technical_context: { domain: 'contacts', components: [] },
+        requirements: ['Number items starting at 1'],
+        acceptance_criteria: ['First item is prefixed "1."'],
+        constraints: [],
+      },
+    },
+    researchFindings: {
+      documentationReferences: [],
+      relevantExamples: [],
+      suggestedApproaches: [],
+      relatedDomains: [],
+      confidence: 0.5,
+      source: 'local-docs',
+    },
+    orchestrationPlan: {
+      summary: '',
+      keyFindings: [],
+      recommendedApproach: '',
+      estimatedComplexity: 'medium',
+      phases: [],
+      riskFactors: [],
+      estimatedEffort: '',
+    },
+    generatedCode,
+    contextFiles: [],
+    testTypes: ['unit'],
+    targetDirectory: '/tmp/cht-core',
+    readFile: async () => null,
+    listDirectory: async () => [],
+  };
+};
+
+const makeMockProvider = (
+  invoke: LLMProvider['invoke'],
+  honorsCustomTools: boolean
+): LLMProvider => ({
+  providerType: 'anthropic',
+  modelName: 'test-model',
+  honorsCustomTools,
+  invoke,
+  async invokeWithMessages(
+    _messages: LLMMessage[],
+    _options?: InvokeOptions
+  ): Promise<LLMResponse> {
+    return { content: '', model: 'test-model' };
+  },
+  async invokeForJSON<T>(): Promise<T> {
+    return {} as T;
+  },
+});
+
+describe('test-gen tool-use gate keys on honorsCustomTools (iter8 A2/A4)', () => {
+  let invokeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    invokeStub.onCall(1).resolves(PHASE2_RESPONSE);
+    invokeStub.onCall(2).resolves(CHECKLIST_RESPONSE);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('forces disableTools and no tools on every invoke when the provider does not honor custom tools', async () => {
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, false));
+    const out = await module.generate(makeToolBoundInput());
+
+    // No retry / no continuation: plan, per-file, checklist.
+    expect(invokeStub.callCount).to.equal(3);
+    expect(out.files).to.have.length(1);
+
+    for (let i = 0; i < invokeStub.callCount; i++) {
+      const opts = invokeStub.getCall(i).args[1] as InvokeOptions;
+      expect(opts.disableTools, `invoke #${i} must set disableTools`).to.equal(true);
+      expect(opts.tools, `invoke #${i} must not carry tools`).to.equal(undefined);
+      expect(opts.toolHandler, `invoke #${i} must not carry a toolHandler`).to.equal(undefined);
+    }
+  });
+
+  it('keeps tools on the Phase-2 call when the provider honors custom tools (no A8 regression)', async () => {
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, true));
+    await module.generate(makeToolBoundInput());
+
+    expect(invokeStub.callCount).to.equal(3);
+    const phase2 = invokeStub.getCall(1).args[1] as InvokeOptions;
+    expect(phase2.tools, 'Phase-2 must carry tools when the provider honors them').to.be.an('array')
+      .that.is.not.empty;
+    expect(
+      phase2.toolHandler,
+      'Phase-2 must carry a toolHandler when the provider honors tools'
+    ).to.be.a('function');
+    expect(
+      phase2.disableTools,
+      'Phase-2 must not disable tools when the provider honors them'
+    ).to.not.equal(true);
+  });
+});
+
+describe('test-gen skips Phase-3 checklist when 0 files generated (iter7 C2/C3)', () => {
+  // The checklist invoke is the only call that uses temperature 0.2 (plan and
+  // per-file use 0.3), so its presence/absence is detectable without coupling to
+  // the retry count.
+  const CHECKLIST_TEMPERATURE = 0.2;
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('makes no checklist invoke when generation yields 0 files', async () => {
+    const invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    // Every per-file attempt returns prose that fails the content assertions
+    // (no import/describe/it), so all retries fail and 0 files are produced.
+    invokeStub.resolves(makeResponse('Unable to produce a test file for this source.'));
+    const provider = makeMockProvider(invokeStub, true);
+
+    const module = new ClaudeApiTestGenModule(provider);
+    const out = await module.generate(makeToolBoundInput());
+
+    expect(out.files).to.have.length(0);
+    const checklistCalls = invokeStub
+      .getCalls()
+      .filter(
+        (c) => (c.args[1] as InvokeOptions | undefined)?.temperature === CHECKLIST_TEMPERATURE
+      );
+    expect(checklistCalls, 'no Phase-3 checklist invoke when 0 files').to.have.length(0);
+    expect(out.requirementsChecklist).to.deep.equal([]);
+  });
+});

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -146,8 +146,8 @@ describe('test-gen tool-use gate keys on honorsCustomTools (iter8 A2/A4)', () =>
     for (let i = 0; i < invokeStub.callCount; i++) {
       const opts = invokeStub.getCall(i).args[1] as InvokeOptions;
       expect(opts.disableTools, `invoke #${i} must set disableTools`).to.equal(true);
-      expect(opts.tools, `invoke #${i} must not carry tools`).to.equal(undefined);
-      expect(opts.toolHandler, `invoke #${i} must not carry a toolHandler`).to.equal(undefined);
+      expect(opts.tools, `invoke #${i} must not carry tools`).to.be.undefined;
+      expect(opts.toolHandler, `invoke #${i} must not carry a toolHandler`).to.be.undefined;
     }
   });
 

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -324,3 +324,36 @@ describe('test-gen never overwrites an existing spec (F-A, C1)', () => {
     expect(out.files[0].path).to.equal('gen.spec.ts');
   });
 });
+
+describe('test-gen first-gen parse hardening (F-B, C1)', () => {
+  afterEach(() => sinon.restore());
+
+  it('parses a CLI-style preamble+fence+trailing-prose response cleanly on the FIRST attempt', async () => {
+    const messy = makeResponse(
+      "Here's the test file you asked for:\n" +
+      "```typescript\n" +
+      "import { expect } from 'chai';\n" +
+      "describe('seam', () => {\n  it('works', () => {\n    expect(1).to.equal(1);\n  });\n});\n" +
+      "```\n" +
+      "Hope this helps! Let me know if you need changes.",
+      'end_turn',
+    );
+    const invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    invokeStub.onCall(1).resolves(messy);
+    invokeStub.onCall(2).resolves(CHECKLIST_RESPONSE);
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, false));
+
+    const out = await module.generate(makeToolBoundInput());
+
+    // plan + per-file + checklist = 3: the messy response parsed on the first
+    // attempt (no retry burned), which is the F-B win.
+    expect(invokeStub.callCount).to.equal(3);
+    expect(out.files).to.have.length(1);
+    const content = out.files[0].content;
+    expect(content).to.include("import { expect } from 'chai'");
+    expect(content).to.not.include('```');           // wrapping fence stripped
+    expect(content).to.not.include('Hope this helps'); // trailing prose stripped
+    expect(content.startsWith("Here's")).to.be.false;  // leading preamble stripped
+  });
+});

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -258,3 +258,32 @@ describe('test-gen tool handler rejects unsafe paths (H3, C1)', () => {
     expect(out).to.equal('file contents');
   });
 });
+
+describe('test-gen plan schema is authoritative (M1, C4)', () => {
+  afterEach(() => sinon.restore());
+
+  const makePlan = (items: string) =>
+    makeResponse(`=== TEST PLAN ===\n${items}\n=== END TEST PLAN ===`, 'end_turn');
+
+  it('drops an invalid plan item and surfaces a warning, keeping valid items', async () => {
+    const invokeStub = sinon.stub();
+    // Item 1 is valid (.spec path, 10+ char description); item 2 has a non-.spec
+    // path so TestPlanItemSchema rejects it — it must be dropped with a warning,
+    // not silently kept (the old validate-and-ignore behavior).
+    invokeStub.onCall(0).resolves(makePlan(
+      '1. unit tests/a.spec.ts -> src/a.ts - Cover the happy path thoroughly\n' +
+      '2. unit tests/b.ts -> src/b.ts - Cover the error path thoroughly'
+    ));
+    invokeStub.onCall(1).resolves(PHASE2_RESPONSE);
+    invokeStub.onCall(2).resolves(CHECKLIST_RESPONSE);
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, false));
+
+    const out = await module.generate(makeToolBoundInput());
+
+    expect(out.files).to.have.length(1);
+    expect(out.warnings ?? []).to.satisfy(
+      (w: string[]) => w.some(s => /Dropped invalid test-plan item.*b\.ts/.test(s)),
+      'a dropped plan item must surface a warning',
+    );
+  });
+});

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -219,6 +219,11 @@ describe('test-gen tool handler rejects unsafe paths (H3, C1)', () => {
     const input: TestGenModuleInput = { ...makeToolBoundInput(), readFile, listDirectory };
     await module.generate(input);
     const phase2 = invokeStub.getCall(1).args[1] as InvokeOptions;
+    // resolveTargetPaths (F-A) legitimately calls readFile during generate() for
+    // its existence check; reset the spies so the assertions below isolate what
+    // the TOOL HANDLER does, not that earlier phase.
+    readFile.resetHistory();
+    listDirectory.resetHistory();
     return phase2.toolHandler!;
   };
 
@@ -285,5 +290,37 @@ describe('test-gen plan schema is authoritative (M1, C4)', () => {
       (w: string[]) => w.some(s => /Dropped invalid test-plan item.*b\.ts/.test(s)),
       'a dropped plan item must surface a warning',
     );
+  });
+});
+
+describe('test-gen never overwrites an existing spec (F-A, C1)', () => {
+  afterEach(() => sinon.restore());
+
+  // PLAN_RESPONSE plans exactly one file: gen.spec.ts.
+  const wire = (readFile: (p: string) => Promise<string | null>) => {
+    const invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    invokeStub.onCall(1).resolves(PHASE2_RESPONSE);
+    invokeStub.onCall(2).resolves(CHECKLIST_RESPONSE);
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, false));
+    const input: TestGenModuleInput = { ...makeToolBoundInput(), readFile };
+    return module.generate(input);
+  };
+
+  it('redirects to an .additional sibling when the canonical spec already exists', async () => {
+    const out = await wire(async (p) => (p === 'gen.spec.ts' ? 'existing 744-line spec' : null));
+    expect(out.files).to.have.length(1);
+    expect(out.files[0].path).to.equal('gen.additional.spec.ts');
+  });
+
+  it('bumps a counter when the .additional sibling also already exists', async () => {
+    const existing = new Set(['gen.spec.ts', 'gen.additional.spec.ts']);
+    const out = await wire(async (p) => (existing.has(p) ? 'exists' : null));
+    expect(out.files[0].path).to.equal('gen.additional.2.spec.ts');
+  });
+
+  it('keeps the canonical path when no spec exists at the target', async () => {
+    const out = await wire(async () => null);
+    expect(out.files[0].path).to.equal('gen.spec.ts');
   });
 });

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -357,3 +357,27 @@ describe('test-gen first-gen parse hardening (F-B, C1)', () => {
     expect(content.startsWith("Here's")).to.be.false;  // leading preamble stripped
   });
 });
+
+describe('test-gen routes the real parse-failure reason into the retry prompt (F-B, C2)', () => {
+  afterEach(() => sinon.restore());
+
+  it('feeds the specific parse reason (not a generic message) to the retry', async () => {
+    const prose = makeResponse(
+      'This is a description of what the test should verify, but it is only prose with no actual code at all.',
+      'end_turn',
+    );
+    const invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    invokeStub.onCall(1).resolves(prose);            // fails looksLikeCodeContent -> unusable
+    invokeStub.onCall(2).resolves(PHASE2_RESPONSE);  // retry recovers
+    invokeStub.onCall(3).resolves(CHECKLIST_RESPONSE);
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, false));
+
+    const out = await module.generate(makeToolBoundInput());
+
+    expect(out.files).to.have.length(1); // recovered on the retry
+    const retryPrompt = invokeStub.getCall(2).args[0] as string;
+    expect(retryPrompt).to.match(/did not parse as code/i); // the specific reason reached the prompt
+    expect(retryPrompt).to.not.include('LLM call returned no usable content'); // not the old generic message
+  });
+});

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -201,3 +201,60 @@ describe('test-gen skips Phase-3 checklist when 0 files generated (iter7 C2/C3)'
     expect(out.requirementsChecklist).to.deep.equal([]);
   });
 });
+
+describe('test-gen tool handler rejects unsafe paths (H3, C1)', () => {
+  afterEach(() => sinon.restore());
+
+  // Drive generate() on a honors-tools provider and capture the toolHandler wired
+  // onto the Phase-2 invoke, with readFile/listDirectory as spies.
+  const captureToolHandler = async (
+    readFile: sinon.SinonStub,
+    listDirectory: sinon.SinonStub,
+  ): Promise<NonNullable<InvokeOptions['toolHandler']>> => {
+    const invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    invokeStub.onCall(1).resolves(PHASE2_RESPONSE);
+    invokeStub.onCall(2).resolves(CHECKLIST_RESPONSE);
+    const module = new ClaudeApiTestGenModule(makeMockProvider(invokeStub, true));
+    const input: TestGenModuleInput = { ...makeToolBoundInput(), readFile, listDirectory };
+    await module.generate(input);
+    const phase2 = invokeStub.getCall(1).args[1] as InvokeOptions;
+    return phase2.toolHandler!;
+  };
+
+  it('rejects a non-string path without calling readFile', async () => {
+    const readFile = sinon.stub().resolves('secret');
+    const listDirectory = sinon.stub().resolves([]);
+    const handler = await captureToolHandler(readFile, listDirectory);
+    const out = await handler('read_file', { path: 42 });
+    expect(out).to.match(/must be a string/);
+    expect(readFile.called).to.be.false;
+  });
+
+  it('rejects an absolute path (arbitrary read) without calling readFile', async () => {
+    const readFile = sinon.stub().resolves('root:x:0:0:...');
+    const listDirectory = sinon.stub().resolves([]);
+    const handler = await captureToolHandler(readFile, listDirectory);
+    const out = await handler('read_file', { path: '/etc/passwd' });
+    expect(out).to.match(/absolute paths are not allowed/);
+    expect(readFile.called).to.be.false;
+  });
+
+  it('rejects a traversal path without calling listDirectory', async () => {
+    const readFile = sinon.stub().resolves(null);
+    const listDirectory = sinon.stub().resolves(['secret-entry']);
+    const handler = await captureToolHandler(readFile, listDirectory);
+    const out = await handler('list_directory', { path: '../../etc' });
+    expect(out).to.match(/escapes the workspace/);
+    expect(listDirectory.called).to.be.false;
+  });
+
+  it('allows a valid relative path through to readFile', async () => {
+    const readFile = sinon.stub().resolves('file contents');
+    const listDirectory = sinon.stub().resolves([]);
+    const handler = await captureToolHandler(readFile, listDirectory);
+    const out = await handler('read_file', { path: 'api/src/controllers/contacts.js' });
+    expect(readFile.calledOnceWithExactly('api/src/controllers/contacts.js')).to.be.true;
+    expect(out).to.equal('file contents');
+  });
+});

--- a/test/layers/test-gen/cli-disable-tools-seam.spec.ts
+++ b/test/layers/test-gen/cli-disable-tools-seam.spec.ts
@@ -228,7 +228,9 @@ describe('test-gen tool handler rejects unsafe paths (H3, C1)', () => {
   };
 
   it('rejects a non-string path without calling readFile', async () => {
-    const readFile = sinon.stub().resolves('secret');
+    // readFile returns null (nothing exists) so resolveTargetPaths keeps the
+    // canonical plan path; the handler still rejects the unsafe path before readFile.
+    const readFile = sinon.stub().resolves(null);
     const listDirectory = sinon.stub().resolves([]);
     const handler = await captureToolHandler(readFile, listDirectory);
     const out = await handler('read_file', { path: 42 });
@@ -237,7 +239,7 @@ describe('test-gen tool handler rejects unsafe paths (H3, C1)', () => {
   });
 
   it('rejects an absolute path (arbitrary read) without calling readFile', async () => {
-    const readFile = sinon.stub().resolves('root:x:0:0:...');
+    const readFile = sinon.stub().resolves(null);
     const listDirectory = sinon.stub().resolves([]);
     const handler = await captureToolHandler(readFile, listDirectory);
     const out = await handler('read_file', { path: '/etc/passwd' });
@@ -255,7 +257,10 @@ describe('test-gen tool handler rejects unsafe paths (H3, C1)', () => {
   });
 
   it('allows a valid relative path through to readFile', async () => {
-    const readFile = sinon.stub().resolves('file contents');
+    // Default null (so resolveTargetPaths keeps the canonical plan path); the
+    // valid tool-read path returns content.
+    const readFile = sinon.stub().resolves(null);
+    readFile.withArgs('api/src/controllers/contacts.js').resolves('file contents');
     const listDirectory = sinon.stub().resolves([]);
     const handler = await captureToolHandler(readFile, listDirectory);
     const out = await handler('read_file', { path: 'api/src/controllers/contacts.js' });
@@ -322,6 +327,13 @@ describe('test-gen never overwrites an existing spec (F-A, C1)', () => {
   it('keeps the canonical path when no spec exists at the target', async () => {
     const out = await wire(async () => null);
     expect(out.files[0].path).to.equal('gen.spec.ts');
+  });
+
+  it('fails closed (0 files) when every sibling up to the cap exists, never returning an existing path (F-A cap)', async () => {
+    // readFile returns non-null for EVERYTHING: the canonical path and every
+    // .additional[.N] sibling "exist", so no free sibling is found.
+    const out = await wire(async () => 'exists');
+    expect(out.files).to.have.length(0);
   });
 });
 

--- a/test/layers/test-gen/continuation-seam.spec.ts
+++ b/test/layers/test-gen/continuation-seam.spec.ts
@@ -1,0 +1,216 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ClaudeApiTestGenModule } from '../../../src/layers/test-gen/modules/claude-api';
+import { TestGenModuleInput } from '../../../src/layers/test-gen/interface';
+import { GeneratedFile } from '../../../src/types';
+import { LLMProvider, LLMResponse, LLMMessage, InvokeOptions } from '../../../src/llm';
+
+/**
+ * M3 (C6): the truncation/continuation path. The rest of the suite pins the
+ * no-continuation path; this drives generate() with a provider whose first
+ * per-file response reports stopReason 'max_tokens', exercising the seam that
+ * was entirely untested. Provider is honorsCustomTools=false and the input binds
+ * no readFile/listDirectory, so the only invokes are plan, per-file, continuation(s),
+ * checklist — a deterministic call sequence.
+ */
+
+const makeResp = (
+  content: string,
+  stopReason?: string,
+  usage: { inputTokens: number; outputTokens: number } = { inputTokens: 100, outputTokens: 100 },
+): LLMResponse => ({ content, model: 'test-model', usage, stopReason });
+
+const makeProvider = (invoke: LLMProvider['invoke']): LLMProvider => ({
+  providerType: 'anthropic',
+  modelName: 'test-model',
+  honorsCustomTools: false,
+  invoke,
+  async invokeWithMessages(_m: LLMMessage[], _o?: InvokeOptions): Promise<LLMResponse> {
+    return { content: '', model: 'test-model' };
+  },
+  async invokeForJSON<T>(): Promise<T> {
+    return {} as T;
+  },
+});
+
+const PLAN = makeResp(
+  `=== TEST PLAN ===
+1. unit gen.spec.ts -> source.ts - Unit tests for the formatter under continuation
+=== END TEST PLAN ===`,
+);
+const CHECKLIST = makeResp('{"checklist": []}');
+
+const makeInput = (): TestGenModuleInput => {
+  const generatedCode: GeneratedFile[] = [
+    {
+      relativePath: 'source.ts',
+      content: 'export const f = (): string => "";',
+      language: 'typescript',
+      type: 'source',
+      description: 'f under test',
+      action: 'create',
+    },
+  ];
+  return {
+    ticket: {
+      issue: {
+        title: 'Continuation',
+        type: 'feature',
+        priority: 'medium',
+        description: 'Exercise the continuation seam.',
+        technical_context: { domain: 'contacts', components: [] },
+        requirements: ['works'],
+        acceptance_criteria: ['works'],
+        constraints: [],
+      },
+    },
+    researchFindings: {
+      documentationReferences: [],
+      relevantExamples: [],
+      suggestedApproaches: [],
+      relatedDomains: [],
+      confidence: 0.5,
+      source: 'local-docs',
+    },
+    orchestrationPlan: {
+      summary: '',
+      keyFindings: [],
+      recommendedApproach: '',
+      estimatedComplexity: 'medium',
+      phases: [],
+      riskFactors: [],
+      estimatedEffort: '',
+    },
+    generatedCode,
+    contextFiles: [],
+    testTypes: ['unit'],
+    targetDirectory: '/tmp/cht-core',
+  };
+};
+
+describe('test-gen continuation seam (M3, C6)', () => {
+  afterEach(() => sinon.restore());
+
+  it('assembles a truncated file across one continuation (happy path)', async () => {
+    const first = makeResp(
+      "import { expect } from 'chai';\ndescribe('x', () => {\n  it('works', () => {\n    expect(1).to",
+      'max_tokens',
+    );
+    const cont = makeResp('.equal(1);\n  });\n});', 'end_turn');
+    const invoke = sinon.stub();
+    invoke.onCall(0).resolves(PLAN);
+    invoke.onCall(1).resolves(first);
+    invoke.onCall(2).resolves(cont);
+    invoke.resolves(CHECKLIST);
+
+    const out = await new ClaudeApiTestGenModule(makeProvider(invoke)).generate(makeInput());
+
+    expect(out.files).to.have.length(1);
+    expect(out.files[0].content).to.include('expect(1)');
+    expect(out.files[0].content).to.include('.equal(1)');
+  });
+
+  it('does NOT preamble-strip a prose-looking continuation line (M3a)', async () => {
+    // The continuation resumes a template literal; its first line reads like prose
+    // ("Note continues here`;") and is followed by a column-0 code line, exactly
+    // what stripReasoningPreamble would drop — which would leave the template
+    // literal unterminated. The continuation-only parser must keep it verbatim.
+    const first = makeResp(
+      "import { expect } from 'chai';\ndescribe('x', () => {\n  it('keeps the line', () => {\n    const note = `Start of note",
+      'max_tokens',
+    );
+    const cont = makeResp("Note continues here`;\nconst done = true;\nexpect(note).to.contain('note');\n  });\n});", 'end_turn');
+    const invoke = sinon.stub();
+    invoke.onCall(0).resolves(PLAN);
+    invoke.onCall(1).resolves(first);
+    invoke.onCall(2).resolves(cont);
+    invoke.resolves(CHECKLIST);
+
+    const out = await new ClaudeApiTestGenModule(makeProvider(invoke)).generate(makeInput());
+
+    expect(out.files, 'the assembled file should parse and be accepted').to.have.length(1);
+    expect(out.files[0].content).to.include('Note continues here');
+  });
+
+  it('treats a failed continuation call as a dropped file, not a truncated success (M3b)', async () => {
+    const first = makeResp(
+      "import { expect } from 'chai';\ndescribe('x', () => {\n  it('works', () => {\n    expect(1).to",
+      'max_tokens',
+    );
+    const invoke = sinon.stub();
+    invoke.onCall(0).resolves(PLAN);
+    invoke.onCall(1).resolves(first);
+    invoke.onCall(2).rejects(new Error('network blip'));
+    invoke.resolves(CHECKLIST);
+
+    const out = await new ClaudeApiTestGenModule(makeProvider(invoke)).generate(makeInput());
+
+    // The original truncated content must NOT be accepted as a completed file.
+    expect(out.files).to.have.length(0);
+  });
+
+  it('strips a dangling opening/closing fence around the assembled file (M3c)', async () => {
+    // First response opens ```typescript without a balanced close (truncated), so
+    // parseSingleFileContent cannot strip it; the continuation closes it with a
+    // trailing ```. The assembled file must contain neither fence line.
+    const first = makeResp(
+      "```typescript\nimport { expect } from 'chai';\ndescribe('x', () => {\n  it('works', () => {\n    expect(1)",
+      'max_tokens',
+    );
+    const cont = makeResp('.to.equal(1);\n  });\n});\n```', 'end_turn');
+    const invoke = sinon.stub();
+    invoke.onCall(0).resolves(PLAN);
+    invoke.onCall(1).resolves(first);
+    invoke.onCall(2).resolves(cont);
+    invoke.resolves(CHECKLIST);
+
+    const out = await new ClaudeApiTestGenModule(makeProvider(invoke)).generate(makeInput());
+
+    expect(out.files).to.have.length(1);
+    expect(out.files[0].content, 'no fence lines should survive').to.not.include('```');
+    expect(out.files[0].content).to.include("import { expect } from 'chai'");
+  });
+
+  it('drops the file when the continuation budget is exhausted (over-budget cap)', async () => {
+    const original = process.env.TEST_GEN_MAX_CONTINUATIONS;
+    process.env.TEST_GEN_MAX_CONTINUATIONS = '2';
+    try {
+      const first = makeResp('import { expect } from "chai";\ndescribe("x", () => {', 'max_tokens');
+      const stillTruncated = makeResp('// more, still truncated', 'max_tokens');
+      const invoke = sinon.stub();
+      invoke.onCall(0).resolves(PLAN);
+      invoke.onCall(1).resolves(first);
+      invoke.onCall(2).resolves(stillTruncated);
+      invoke.onCall(3).resolves(stillTruncated);
+      invoke.resolves(CHECKLIST);
+
+      const out = await new ClaudeApiTestGenModule(makeProvider(invoke)).generate(makeInput());
+
+      expect(out.files).to.have.length(0);
+    } finally {
+      if (original === undefined) delete process.env.TEST_GEN_MAX_CONTINUATIONS;
+      else process.env.TEST_GEN_MAX_CONTINUATIONS = original;
+    }
+  });
+
+  it('sums token usage across plan, first response, and continuation', async () => {
+    const first = makeResp(
+      "import { expect } from 'chai';\ndescribe('x', () => {\n  it('works', () => {\n    expect(1).to",
+      'max_tokens',
+      { inputTokens: 5, outputTokens: 5 },
+    );
+    const cont = makeResp('.equal(1);\n  });\n});', 'end_turn', { inputTokens: 7, outputTokens: 3 });
+    const plan = makeResp(PLAN.content, undefined, { inputTokens: 10, outputTokens: 20 });
+    const checklist = makeResp('{"checklist": []}', undefined, { inputTokens: 2, outputTokens: 8 });
+    const invoke = sinon.stub();
+    invoke.onCall(0).resolves(plan);
+    invoke.onCall(1).resolves(first);
+    invoke.onCall(2).resolves(cont);
+    invoke.onCall(3).resolves(checklist);
+
+    const out = await new ClaudeApiTestGenModule(makeProvider(invoke)).generate(makeInput());
+
+    // 30 (plan) + 10 (first) + 10 (continuation) + 10 (checklist)
+    expect(out.tokensUsed).to.equal(60);
+  });
+});

--- a/test/layers/test-gen/schemas.spec.ts
+++ b/test/layers/test-gen/schemas.spec.ts
@@ -1,0 +1,221 @@
+import { expect } from 'chai';
+import { TestContentAssertions, TestPlanSchema, RequirementsChecklistSchema } from '../../../src/layers/test-gen/schemas';
+
+describe('TestContentAssertions', () => {
+  describe('hasTestStructure', () => {
+    it('should pass when describe and it blocks exist', () => {
+      const content = `describe('MyService', () => { it('should work', () => { expect(true).to.be.true; }); });`;
+      expect(TestContentAssertions.hasTestStructure(content)).to.deep.equal([]);
+    });
+
+    it('should fail when describe block is missing', () => {
+      const content = `it('should work', () => { expect(true).to.be.true; });`;
+      const failures = TestContentAssertions.hasTestStructure(content);
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('describe()');
+    });
+
+    it('should fail when it/test block is missing', () => {
+      const content = `describe('MyService', () => { const x = 1; });`;
+      const failures = TestContentAssertions.hasTestStructure(content);
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('it()');
+    });
+
+    it('should accept test() as alternative to it()', () => {
+      const content = `describe('MyService', () => { test('should work', () => {}); });`;
+      expect(TestContentAssertions.hasTestStructure(content)).to.deep.equal([]);
+    });
+  });
+
+  describe('hasAssertions', () => {
+    it('should pass when expect assertions exist', () => {
+      const content = `expect(result).to.equal(42);`;
+      expect(TestContentAssertions.hasAssertions(content)).to.deep.equal([]);
+    });
+
+    it('should pass when assert style is used', () => {
+      const content = `assert.equal(result, 42);`;
+      expect(TestContentAssertions.hasAssertions(content)).to.deep.equal([]);
+    });
+
+    it('should fail when no assertions exist', () => {
+      const content = `const x = 1;\nconst y = 2;`;
+      const failures = TestContentAssertions.hasAssertions(content);
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('no assertions');
+    });
+  });
+
+  describe('hasProperImports', () => {
+    it('should pass with import statement', () => {
+      const content = `import { expect } from 'chai';`;
+      expect(TestContentAssertions.hasProperImports(content, 'test.spec.ts')).to.deep.equal([]);
+    });
+
+    it('should pass with require statement', () => {
+      const content = `const { expect } = require('chai');`;
+      expect(TestContentAssertions.hasProperImports(content, 'test.spec.js')).to.deep.equal([]);
+    });
+
+    it('should fail when no imports exist', () => {
+      const content = `describe('test', () => {});`;
+      const failures = TestContentAssertions.hasProperImports(content, 'test.spec.ts');
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('no import');
+    });
+  });
+
+  describe('isNotPlaintext', () => {
+    it('should pass for code content', () => {
+      const content = `import { expect } from 'chai';\ndescribe('test', () => {});`;
+      expect(TestContentAssertions.isNotPlaintext(content)).to.deep.equal([]);
+    });
+
+    it('should fail for plaintext description', () => {
+      const content = `This test file contains unit tests for the contacts module.\nIt should test all the main functions.`;
+      const failures = TestContentAssertions.isNotPlaintext(content);
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('plaintext');
+    });
+
+    it('should fail for empty content', () => {
+      const content = `// just a comment\n/* another comment */`;
+      const failures = TestContentAssertions.isNotPlaintext(content);
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('empty');
+    });
+  });
+
+  describe('parsesAsCode', () => {
+    it('returns no failures for a well-formed TS file', () => {
+      const content = `import { expect } from 'chai';\ndescribe('x', () => { it('works', () => { expect(1).to.equal(1); }); });`;
+      expect(TestContentAssertions.parsesAsCode(content, 'x.spec.ts')).to.deep.equal([]);
+    });
+
+    it('returns no failures for a well-formed JS file', () => {
+      const content = `const { expect } = require('chai');\ndescribe('x', () => { it('works', () => { expect(1).to.equal(1); }); });`;
+      expect(TestContentAssertions.parsesAsCode(content, 'x.spec.js')).to.deep.equal([]);
+    });
+
+    it('flags a file whose code is preceded by a leaked reasoning preamble', () => {
+      const content = [
+        `angular global is not directly available in this context. Here is the complete test file:`,
+        `import { expect } from 'chai';`,
+        `describe('version', () => { it('parses', () => { expect(1).to.equal(1); }); });`,
+      ].join('\n');
+      const failures = TestContentAssertions.parsesAsCode(content, 'version.spec.js');
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('does not parse');
+    });
+  });
+
+  describe('validateTestFile', () => {
+    it('should pass for a well-formed test file', () => {
+      const content = [
+        `import { expect } from 'chai';`,
+        `import sinon from 'sinon';`,
+        ``,
+        `describe('ContactsService', () => {`,
+        `  afterEach(() => sinon.restore());`,
+        ``,
+        `  it('should find contacts by phone', () => {`,
+        `    expect(result).to.have.length(1);`,
+        `  });`,
+        `});`,
+      ].join('\n');
+
+      expect(TestContentAssertions.validateTestFile(content, 'contacts.spec.ts')).to.deep.equal([]);
+    });
+
+    it('should return multiple failures for a bad test file', () => {
+      const content = `To test this module you need to check the contacts.`;
+      const failures = TestContentAssertions.validateTestFile(content, 'test.spec.ts');
+      expect(failures.length).to.be.greaterThan(1);
+    });
+
+    it('rejects an otherwise-valid file that fails to parse (leaked preamble, F6)', () => {
+      const content = [
+        `angular global is not directly available in this context. Here is the complete test file:`,
+        `import { expect } from 'chai';`,
+        `describe('version', () => { it('parses', () => { expect(1).to.equal(1); }); });`,
+      ].join('\n');
+      // The substring checks all pass (import/describe/it/expect present, no
+      // plaintext indicator), so only the parse check catches this.
+      expect(TestContentAssertions.hasProperImports(content, 'version.spec.js')).to.deep.equal([]);
+      expect(TestContentAssertions.hasTestStructure(content)).to.deep.equal([]);
+      expect(TestContentAssertions.hasAssertions(content)).to.deep.equal([]);
+      expect(TestContentAssertions.isNotPlaintext(content)).to.deep.equal([]);
+
+      const failures = TestContentAssertions.validateTestFile(content, 'version.spec.js');
+      expect(failures.some(f => f.includes('does not parse'))).to.equal(true);
+    });
+  });
+});
+
+describe('TestPlanSchema', () => {
+  it('should validate a correct plan', () => {
+    const plan = {
+      items: [{
+        filePath: 'tests/unit/contacts.spec.js',
+        testType: 'unit',
+        targetSourceFile: 'api/src/controllers/contacts.js',
+        description: 'Unit tests for contacts controller',
+      }],
+    };
+
+    const result = TestPlanSchema.safeParse(plan);
+    expect(result.success).to.be.true;
+  });
+
+  it('should reject a plan with invalid test file path', () => {
+    const plan = {
+      items: [{
+        filePath: 'tests/unit/contacts.js',
+        testType: 'unit',
+        targetSourceFile: 'api/src/controllers/contacts.js',
+        description: 'Unit tests for contacts controller',
+      }],
+    };
+
+    const result = TestPlanSchema.safeParse(plan);
+    expect(result.success).to.be.false;
+  });
+
+  it('should reject an empty plan', () => {
+    const plan = { items: [] };
+
+    const result = TestPlanSchema.safeParse(plan);
+    expect(result.success).to.be.false;
+  });
+});
+
+describe('RequirementsChecklistSchema', () => {
+  it('should validate a correct checklist', () => {
+    const checklist = {
+      checklist: [{
+        requirement: 'Support search by phone number',
+        scenarios: [{
+          name: 'should find contact by exact phone number',
+          type: 'happy-path',
+          description: 'Verifies exact match phone lookup',
+        }],
+      }],
+    };
+
+    const result = RequirementsChecklistSchema.safeParse(checklist);
+    expect(result.success).to.be.true;
+  });
+
+  it('should reject a checklist with empty scenarios', () => {
+    const checklist = {
+      checklist: [{
+        requirement: 'Support search',
+        scenarios: [],
+      }],
+    };
+
+    const result = RequirementsChecklistSchema.safeParse(checklist);
+    expect(result.success).to.be.false;
+  });
+});

--- a/test/layers/test-gen/schemas.spec.ts
+++ b/test/layers/test-gen/schemas.spec.ts
@@ -45,6 +45,25 @@ describe('TestContentAssertions', () => {
       expect(failures).to.have.length(1);
       expect(failures[0]).to.include('no assertions');
     });
+
+    it('should fail on a hollow describe/it shell with no real assertion (H2)', () => {
+      // describe/it are structure, not assertions: this empty shell must fail the
+      // assertion gate even though it "looks" like a test.
+      const content = `describe('x', () => { it('works', () => {}); });`;
+      const failures = TestContentAssertions.hasAssertions(content);
+      expect(failures).to.have.length(1);
+      expect(failures[0]).to.include('no assertions');
+    });
+
+    it('should fail when only an `expect` import is present (no assertion call) (H2)', () => {
+      const content = `import { expect } from 'chai';\ndescribe('x', () => { it('works', () => {}); });`;
+      expect(TestContentAssertions.hasAssertions(content)).to.have.length(1);
+    });
+
+    it('should pass with a property-style .should assertion', () => {
+      const content = `result.should.equal(42);`;
+      expect(TestContentAssertions.hasAssertions(content)).to.deep.equal([]);
+    });
   });
 
   describe('hasProperImports', () => {

--- a/test/layers/test-gen/semantic-correctness-gate.spec.ts
+++ b/test/layers/test-gen/semantic-correctness-gate.spec.ts
@@ -1,0 +1,193 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { ClaudeApiTestGenModule } from '../../../src/layers/test-gen/modules/claude-api';
+import { TestGenModuleInput } from '../../../src/layers/test-gen/interface';
+import { GeneratedFile } from '../../../src/types';
+import { LLMProvider, LLMResponse, LLMMessage, InvokeOptions } from '../../../src/llm';
+
+/**
+ * HARNESS section 8.3 semantic-correctness gate.
+ *
+ * Drives the real ClaudeApiTestGenModule.generate() with a stubbed LLM, takes
+ * the emitted test file, and spawn-executes it (repo mocha + ts-node) against a
+ * buggy and a fixed source. The emitted test must FAIL on buggy and PASS on
+ * fixed. This proves the layer's generated tests catch bugs, not just pass CI.
+ *
+ * Fixtures: test/fixtures/test-gen/semantic-gate/ (see its README).
+ */
+
+const REPO = path.resolve(__dirname, '../../..');
+const FIXTURES = path.resolve(__dirname, '../../fixtures/test-gen/semantic-gate');
+
+// The canned test the stubbed LLM "emits" on the per-file call. It genuinely
+// probes 1-indexed numbering: passes on source.fixed.ts, fails on source.buggy.ts.
+// It imports the source under test from the per-run temp dir's ./source.
+const CANNED_TEST = `import { expect } from 'chai';
+import { formatListForPrompt } from './source';
+
+describe('formatListForPrompt numbering', () => {
+  it('numbers items starting at 1', () => {
+    const out = formatListForPrompt(['apple', 'banana']);
+    expect(out).to.include('1. apple');
+    expect(out).to.include('2. banana');
+    expect(out).to.not.include('0. apple');
+  });
+});
+`;
+
+const makeResponse = (content: string, stopReason?: string): LLMResponse => ({
+  content,
+  model: 'test-model',
+  usage: { inputTokens: 100, outputTokens: 100 },
+  stopReason,
+});
+
+// Plan call (onCall 0): one valid TEST_PLAN_ITEM_RE line, filePath ends .spec.ts,
+// description >= 10 chars. Parses to a single-item plan -> no empty-plan bailout.
+const PLAN_RESPONSE = makeResponse(
+  `=== TEST PLAN ===
+1. unit gen.spec.ts -> source.ts - Unit tests for formatListForPrompt numbering
+=== END TEST PLAN ===`,
+);
+
+// Checklist call (onCall 2): valid JSON for RequirementsChecklistSchema (empty list ok).
+const CHECKLIST_RESPONSE = makeResponse('{"checklist": []}');
+
+const makeInput = (): TestGenModuleInput => {
+  const generatedCode: GeneratedFile[] = [
+    {
+      relativePath: 'source.ts',
+      content: 'export const formatListForPrompt = (): string => "";',
+      language: 'typescript',
+      type: 'source',
+      description: 'formatListForPrompt under test',
+      action: 'create',
+    },
+  ];
+  return {
+    ticket: {
+      issue: {
+        title: 'List numbering',
+        type: 'feature',
+        priority: 'medium',
+        description: 'Format a list for prompts with 1-indexed numbering.',
+        technical_context: { domain: 'contacts', components: [] },
+        requirements: ['Number items starting at 1'],
+        acceptance_criteria: ['First item is prefixed "1."'],
+        constraints: [],
+      },
+    },
+    researchFindings: {
+      documentationReferences: [],
+      relevantExamples: [],
+      suggestedApproaches: [],
+      relatedDomains: [],
+      confidence: 0.5,
+      source: 'local-docs',
+    },
+    orchestrationPlan: {
+      summary: '',
+      keyFindings: [],
+      recommendedApproach: '',
+      estimatedComplexity: 'medium',
+      phases: [],
+      riskFactors: [],
+      estimatedEffort: '',
+    },
+    generatedCode,
+    contextFiles: [],
+    testTypes: ['unit'],
+    targetDirectory: '/tmp/cht-core',
+  };
+};
+
+/**
+ * Write the emitted test plus the chosen source variant into a fresh temp dir
+ * with a node_modules symlink, spawn the repo mocha against it, return the exit
+ * code. Exit-code only (no stdout parsing); ENOENT/timeout/signal throw so they
+ * can never masquerade as a passing exit 0.
+ */
+const runEmittedTest = (emittedContent: string, variant: 'buggy' | 'fixed'): number => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-semgate-'));
+  try {
+    fs.symlinkSync(path.join(REPO, 'node_modules'), path.join(tmp, 'node_modules'), 'dir');
+    fs.copyFileSync(path.join(FIXTURES, 'tsconfig.json'), path.join(tmp, 'tsconfig.json'));
+    fs.copyFileSync(path.join(FIXTURES, `source.${variant}.ts`), path.join(tmp, 'source.ts'));
+    fs.writeFileSync(path.join(tmp, 'gen.spec.ts'), emittedContent, 'utf-8');
+
+    const res = spawnSync(
+      path.join(REPO, 'node_modules/.bin/mocha'),
+      ['--no-config', '--require', 'ts-node/register', '--extension', 'ts', path.join(tmp, 'gen.spec.ts')],
+      {
+        cwd: tmp,
+        env: { ...process.env, TS_NODE_PROJECT: path.join(tmp, 'tsconfig.json') },
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 30000,
+      },
+    );
+
+    if (res.error) {
+      throw res.error;
+    }
+    if (res.signal) {
+      throw new Error(`inner mocha killed by signal ${res.signal} (variant=${variant})`);
+    }
+    return res.status ?? 1;
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+};
+
+describe('test-gen semantic-correctness gate (HARNESS 8.3)', () => {
+  let invokeStub: sinon.SinonStub;
+  let mockProvider: LLMProvider;
+
+  beforeEach(() => {
+    invokeStub = sinon.stub();
+    invokeStub.onCall(0).resolves(PLAN_RESPONSE);
+    invokeStub.onCall(1).resolves(makeResponse(CANNED_TEST, 'end_turn'));
+    invokeStub.onCall(2).resolves(CHECKLIST_RESPONSE);
+    mockProvider = {
+      providerType: 'anthropic',
+      modelName: 'test-model',
+      honorsCustomTools: true,
+      invoke: invokeStub,
+      async invokeWithMessages(_messages: LLMMessage[], _options?: InvokeOptions): Promise<LLMResponse> {
+        return { content: '', model: 'test-model' };
+      },
+      async invokeForJSON<T>(): Promise<T> {
+        return {} as T;
+      },
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('emits a test that fails on buggy source and passes on fixed source', async () => {
+    const module = new ClaudeApiTestGenModule(mockProvider);
+    const out = await module.generate(makeInput());
+
+    // Pins the no-retry / no-continuation / no-tools path: plan, per-file, checklist.
+    expect(invokeStub.callCount).to.equal(3);
+    expect(out.files).to.have.length(1);
+    expect(out.files[0].path).to.equal('gen.spec.ts');
+
+    const emitted = out.files[0].content;
+    // The emitted test must depend on the buggy behavior, not be a happy-path scaffold.
+    expect(emitted).to.include('1. apple');
+
+    const buggyExit = runEmittedTest(emitted, 'buggy');
+    const fixedExit = runEmittedTest(emitted, 'fixed');
+
+    // mocha exit code equals the failure count (clamped to 255): any nonzero is a fail.
+    expect(buggyExit, 'emitted test must FAIL on buggy source').to.not.equal(0);
+    expect(fixedExit, 'emitted test must PASS on fixed source').to.equal(0);
+  }).timeout(60000);
+});

--- a/test/layers/test-gen/test-gen-registry.spec.ts
+++ b/test/layers/test-gen/test-gen-registry.spec.ts
@@ -1,0 +1,156 @@
+import { expect } from 'chai';
+import { TestGenModule } from '../../../src/layers/test-gen/interface';
+import {
+  TestGenModuleRegistry,
+  createDefaultTestGenRegistry,
+} from '../../../src/layers/test-gen/registry';
+import { LLMProvider, LLMResponse, LLMMessage, InvokeOptions } from '../../../src/llm';
+
+describe('TestGenModuleRegistry', () => {
+  const makeModule = (name: string): TestGenModule => ({
+    name,
+    version: '0.0.1',
+    async generate() {
+      return {
+        files: [],
+        explanation: 'noop',
+        requirementsChecklist: [],
+      };
+    },
+  });
+
+  it('should register and retrieve a module by name', () => {
+    const registry = new TestGenModuleRegistry();
+    const module = makeModule('custom-module');
+
+    registry.register(module);
+
+    expect(registry.get('custom-module')).to.equal(module);
+  });
+
+  it('should return undefined for unregistered module', () => {
+    const registry = new TestGenModuleRegistry();
+
+    expect(registry.get('nonexistent')).to.be.undefined;
+  });
+
+  it('should list all registered module names', () => {
+    const registry = new TestGenModuleRegistry();
+    registry.register(makeModule('mod-a'));
+    registry.register(makeModule('mod-b'));
+
+    expect(registry.list()).to.deep.equal(['mod-a', 'mod-b']);
+  });
+
+  it('should throw when registering a module with a duplicate name', () => {
+    const registry = new TestGenModuleRegistry();
+    registry.register(makeModule('mod-a'));
+
+    expect(() => registry.register(makeModule('mod-a'))).to.throw(
+      'Test generation module "mod-a" is already registered'
+    );
+  });
+
+  it('should resolve anthropic alias to claude-api', () => {
+    const registry = createDefaultTestGenRegistry();
+
+    const active = registry.getActiveModule('anthropic');
+
+    expect(active.name).to.equal('claude-api');
+  });
+
+  it('should resolve claude-cli alias to claude-code-cli', () => {
+    const registry = new TestGenModuleRegistry();
+    const module = makeModule('claude-code-cli');
+    registry.register(module);
+
+    const active = registry.getActiveModule('claude-cli');
+
+    expect(active.name).to.equal('claude-code-cli');
+  });
+
+  it('should pass through unknown aliases as-is', () => {
+    const registry = new TestGenModuleRegistry();
+
+    expect(registry.resolveProvider('some-provider')).to.equal('some-provider');
+  });
+
+  it('should fall back to TEST_GEN_MODULE env var when no argument given', () => {
+    const originalEnv = process.env.TEST_GEN_MODULE;
+    try {
+      process.env.TEST_GEN_MODULE = 'claude-api';
+      const registry = createDefaultTestGenRegistry();
+
+      const active = registry.getActiveModule();
+
+      expect(active.name).to.equal('claude-api');
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.TEST_GEN_MODULE;
+      } else {
+        process.env.TEST_GEN_MODULE = originalEnv;
+      }
+    }
+  });
+
+  it('should fall back to claude-api when no argument and no env var', () => {
+    const originalEnv = process.env.TEST_GEN_MODULE;
+    try {
+      delete process.env.TEST_GEN_MODULE;
+      const registry = createDefaultTestGenRegistry();
+
+      const active = registry.getActiveModule();
+
+      expect(active.name).to.equal('claude-api');
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.TEST_GEN_MODULE = originalEnv;
+      }
+    }
+  });
+
+  it('should throw with helpful message for unknown module', () => {
+    const registry = createDefaultTestGenRegistry();
+
+    expect(() => registry.getActiveModule('unknown-provider')).to.throw(
+      'No test generation module registered for provider "unknown-provider"'
+    );
+  });
+
+  it('should include registered module names in error message', () => {
+    const registry = new TestGenModuleRegistry();
+    registry.register(makeModule('mod-a'));
+    registry.register(makeModule('mod-b'));
+
+    expect(() => registry.getActiveModule('bad')).to.throw('mod-a, mod-b');
+  });
+
+  it('should default registry include claude-api module', () => {
+    const registry = createDefaultTestGenRegistry();
+
+    expect(registry.list()).to.include('claude-api');
+  });
+
+  it('should pass LLM provider through to module via factory', () => {
+    const mockProvider: LLMProvider = {
+      providerType: 'anthropic',
+      modelName: 'test-model',
+      honorsCustomTools: true,
+      async invoke(): Promise<LLMResponse> {
+        return { content: '{}', model: 'test-model' };
+      },
+      async invokeWithMessages(_messages: LLMMessage[], _options?: InvokeOptions): Promise<LLMResponse> {
+        return { content: '{}', model: 'test-model' };
+      },
+      async invokeForJSON<T>(): Promise<T> {
+        return {} as T;
+      },
+    };
+
+    const registry = createDefaultTestGenRegistry(mockProvider);
+
+    const module = registry.getActiveModule('claude-api');
+    expect(module.name).to.equal('claude-api');
+    expect(module.version).to.equal('0.1.0');
+  });
+});

--- a/test/layers/test-gen/test-gen-registry.spec.ts
+++ b/test/layers/test-gen/test-gen-registry.spec.ts
@@ -59,14 +59,14 @@ describe('TestGenModuleRegistry', () => {
     expect(active.name).to.equal('claude-api');
   });
 
-  it('throws a clear error for claude-cli instead of silently resolving to an unregistered module (H1)', () => {
-    // No phantom `claude-cli -> claude-code-cli` alias: there is no CLI test-gen
-    // module yet, so the default registry (claude-api only) must throw a clear
-    // error rather than resolve to an unregistered module (which the non-fatal
-    // wrapper would have turned into a silent 0-file run).
+  it('resolves the claude-cli alias to the claude-api module (H1 completed)', () => {
+    // The single test-gen module is provider-agnostic and runs via `claude -p`
+    // under LLM_PROVIDER=claude-cli, so claude-cli selects it — symmetric with
+    // CODE_GEN_MODULE. (A genuinely-unknown provider still throws; see below.)
     const registry = createDefaultTestGenRegistry();
 
-    expect(() => registry.getActiveModule('claude-cli')).to.throw(/provider "claude-cli".+claude-api/);
+    expect(registry.resolveProvider('claude-cli')).to.equal('claude-api');
+    expect(registry.getActiveModule('claude-cli').name).to.equal('claude-api');
   });
 
   it('should pass through unknown aliases as-is', () => {

--- a/test/layers/test-gen/test-gen-registry.spec.ts
+++ b/test/layers/test-gen/test-gen-registry.spec.ts
@@ -59,14 +59,14 @@ describe('TestGenModuleRegistry', () => {
     expect(active.name).to.equal('claude-api');
   });
 
-  it('should resolve claude-cli alias to claude-code-cli', () => {
-    const registry = new TestGenModuleRegistry();
-    const module = makeModule('claude-code-cli');
-    registry.register(module);
+  it('throws a clear error for claude-cli instead of silently resolving to an unregistered module (H1)', () => {
+    // No phantom `claude-cli -> claude-code-cli` alias: there is no CLI test-gen
+    // module yet, so the default registry (claude-api only) must throw a clear
+    // error rather than resolve to an unregistered module (which the non-fatal
+    // wrapper would have turned into a silent 0-file run).
+    const registry = createDefaultTestGenRegistry();
 
-    const active = registry.getActiveModule('claude-cli');
-
-    expect(active.name).to.equal('claude-code-cli');
+    expect(() => registry.getActiveModule('claude-cli')).to.throw(/provider "claude-cli".+claude-api/);
   });
 
   it('should pass through unknown aliases as-is', () => {

--- a/test/supervisors/development-supervisor.spec.ts
+++ b/test/supervisors/development-supervisor.spec.ts
@@ -499,9 +499,9 @@ describe('DevelopmentSupervisor testGeneration node (iter6, live)', () => {
     const tg = out.testGeneration as { files: unknown[]; warnings?: string[] };
     expect(out.currentPhase).to.equal('complete');
     expect(tg.files).to.deep.equal([]);
-    expect(out.errors).to.equal(undefined);
-    expect(out.validationFeedback).to.equal(undefined);
-    expect(out.perFileFeedback).to.equal(undefined);
+    expect(out.errors).to.be.undefined;
+    expect(out.validationFeedback).to.be.undefined;
+    expect(out.perFileFeedback).to.be.undefined;
     // But the failure is now reported honestly (warning + failed todo), not green.
     expect(tg.warnings ?? []).to.satisfy(
       (w: string[]) => w.some(s => /boom/.test(s)),

--- a/test/supervisors/development-supervisor.spec.ts
+++ b/test/supervisors/development-supervisor.spec.ts
@@ -468,6 +468,22 @@ describe('DevelopmentSupervisor testGeneration node (iter6, live)', () => {
     expect(failSpy.called, 'a no-file result carrying warnings must fail the todo').to.equal(true);
   });
 
+  it('forwards state.validationFeedback to the agent as additionalContext (M6)', async () => {
+    const testGen = sinon.stub().resolves(cannedTestGen);
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
+    const state = mkDevState({
+      ...baseValidInputFragment,
+      codeGeneration: mkCodeGenResult([mkFile('src/a.ts')]),
+      validationFeedback: 'address the failing assertion',
+    });
+
+    await supervisor.testGenerationNode(state);
+
+    expect(testGen.calledOnce).to.equal(true);
+    const agentInput = testGen.firstCall.args[0] as { additionalContext?: string };
+    expect(agentInput.additionalContext).to.equal('address the failing assertion');
+  });
+
   it('stays complete (no fail) when the agent returns no files with NO warnings (intentional no-op) (M2)', async () => {
     const failSpy = sinon.spy(TodoTracker.prototype, 'fail');
     const testGen = sinon.stub().resolves(emptyResult);

--- a/test/supervisors/development-supervisor.spec.ts
+++ b/test/supervisors/development-supervisor.spec.ts
@@ -120,6 +120,7 @@ describe('resolveValidateImplEdge (R17.4)', () => {
 type SupervisorPrivateAccess = {
   codeGenerationNode: (state: unknown) => Promise<Record<string, unknown>>;
   validationNode: (state: unknown) => Promise<Record<string, unknown>>;
+  testGenerationNode: (state: unknown) => Promise<Record<string, unknown>>;
 };
 
 /**
@@ -129,17 +130,32 @@ type SupervisorPrivateAccess = {
  */
 const buildSupervisorWithStubAgents = (
   generateImpl: sinon.SinonStub,
+  opts: { testGenImpl?: sinon.SinonStub; shutdownRequested?: boolean } = {},
 ) => {
   class FakeCodeGenAgent {
     generate = generateImpl;
   }
-  const mod = proxyquire('../../src/supervisors/development-supervisor', {
-    '../agents/code-generation-agent': { CodeGenerationAgent: FakeCodeGenAgent },
+  const testGenerate = opts.testGenImpl ?? sinon.stub().resolves({
+    files: [],
+    explanation: '',
+    requirementsChecklist: [],
   });
+  class FakeTestGenAgent {
+    generate = testGenerate;
+  }
+  const stubs: Record<string, unknown> = {
+    '../agents/code-generation-agent': { CodeGenerationAgent: FakeCodeGenAgent },
+    '../agents/test-generation-agent': { TestGenerationAgent: FakeTestGenAgent },
+  };
+  if (opts.shutdownRequested) {
+    stubs['../utils/shutdown'] = { isShutdownRequested: () => true };
+  }
+  const mod = proxyquire('../../src/supervisors/development-supervisor', stubs);
   const supervisor = new mod.DevelopmentSupervisor({
     llmProvider: mkMockLLM(),
   });
   return supervisor as unknown as SupervisorPrivateAccess & {
+    develop: (input: unknown) => Promise<DevelopmentState>;
     writeToStaging: (state: DevelopmentState) => Promise<{ stagingPath: string; writtenFiles: string[] }>;
     writeToChtCore: (state: DevelopmentState, chtCorePath: string) => Promise<string[]>;
     clearStaging: (stagingPath: string) => Promise<void>;
@@ -355,5 +371,88 @@ describe('DevelopmentSupervisor public file helpers (v9b.1)', () => {
     let threw = false;
     try { await supervisor.clearStaging(stagePath); } catch { threw = true; }
     expect(threw).to.equal(false);
+  });
+});
+
+describe('DevelopmentSupervisor testGeneration node (iter6, live)', () => {
+  const emptyResult = { files: [], explanation: '', requirementsChecklist: [] };
+  const cannedTestGen = {
+    files: [mkFile('tests/unit/a.spec.ts', '// spec\n', 'test')],
+    explanation: 'generated tests',
+    requirementsChecklist: [],
+  };
+  const stateWithCode = () => mkDevState({
+    ...baseValidInputFragment,
+    codeGeneration: mkCodeGenResult([mkFile('src/a.ts')]),
+  });
+
+  it('runs the agent and returns its result on the happy path', async () => {
+    const testGen = sinon.stub().resolves(cannedTestGen);
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
+
+    const out = await supervisor.testGenerationNode(stateWithCode());
+
+    expect(testGen.calledOnce).to.equal(true);
+    expect(out.currentPhase).to.equal('complete');
+    expect(out.testGeneration).to.deep.equal(cannedTestGen);
+  });
+
+  it('no-ops on shutdown without calling the agent', async () => {
+    const testGen = sinon.stub().resolves(cannedTestGen);
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), {
+      testGenImpl: testGen,
+      shutdownRequested: true,
+    });
+
+    const out = await supervisor.testGenerationNode(stateWithCode());
+
+    expect(testGen.notCalled).to.equal(true);
+    expect(out.currentPhase).to.equal('complete');
+    expect(out.testGeneration).to.deep.equal(emptyResult);
+  });
+
+  it('no-ops on empty code-gen without calling the agent', async () => {
+    const testGen = sinon.stub().resolves(cannedTestGen);
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
+
+    const state = mkDevState({
+      ...baseValidInputFragment,
+      codeGeneration: mkCodeGenResult([]),
+    });
+    const out = await supervisor.testGenerationNode(state);
+
+    expect(testGen.notCalled).to.equal(true);
+    expect(out.testGeneration).to.deep.equal(emptyResult);
+  });
+
+  it('is non-fatal when the agent throws: empty result, complete, no errors written', async () => {
+    const testGen = sinon.stub().rejects(new Error('boom'));
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
+
+    const out = await supervisor.testGenerationNode(stateWithCode());
+
+    expect(testGen.calledOnce).to.equal(true);
+    expect(out.currentPhase).to.equal('complete');
+    expect(out.testGeneration).to.deep.equal(emptyResult);
+    expect(out.errors).to.equal(undefined);
+    expect(out.validationFeedback).to.equal(undefined);
+    expect(out.perFileFeedback).to.equal(undefined);
+  });
+
+  it('is reached once after the refinement loop exhausts and populates testGeneration', async () => {
+    // mkMockLLM.invokeForJSON returns {}, so every validation scores 0 and the
+    // resolver loops back to generateCode until iterations exhaust, then routes
+    // the terminal branch through generateTests to END.
+    const generate = sinon.stub().resolves(mkCodeGenResult([mkFile('src/a.ts')]));
+    const testGen = sinon.stub().resolves(cannedTestGen);
+    const supervisor = buildSupervisorWithStubAgents(generate, { testGenImpl: testGen });
+
+    const finalState = await supervisor.develop(baseValidInputFragment);
+
+    expect(generate.callCount).to.equal(3); // refinement loop re-entered generateCode each iteration
+    expect(finalState.iterationCount).to.equal(3); // MAX_ITERATIONS — loop ran and exhausted
+    expect(finalState.currentPhase).to.equal('complete'); // generateTests owns the terminal phase
+    expect(testGen.calledOnce).to.equal(true);
+    expect(finalState.testGeneration).to.deep.equal(cannedTestGen);
   });
 });

--- a/test/supervisors/development-supervisor.spec.ts
+++ b/test/supervisors/development-supervisor.spec.ts
@@ -17,6 +17,7 @@ import {
   GeneratedFile,
 } from '../../src/types';
 import { LLMProvider } from '../../src/llm';
+import { TodoTracker } from '../../src/utils/todo-tracker';
 
 const proxyquire = require('proxyquire').noCallThru();
 
@@ -375,6 +376,8 @@ describe('DevelopmentSupervisor public file helpers (v9b.1)', () => {
 });
 
 describe('DevelopmentSupervisor testGeneration node (iter6, live)', () => {
+  afterEach(() => sinon.restore());
+
   const emptyResult = { files: [], explanation: '', requirementsChecklist: [] };
   const cannedTestGen = {
     files: [mkFile('tests/unit/a.spec.ts', '// spec\n', 'test')],
@@ -425,18 +428,57 @@ describe('DevelopmentSupervisor testGeneration node (iter6, live)', () => {
     expect(out.testGeneration).to.deep.equal(emptyResult);
   });
 
-  it('is non-fatal when the agent throws: empty result, complete, no errors written', async () => {
+  it('is non-fatal when the agent throws, but marks the todo failed with a warning (M2)', async () => {
+    const failSpy = sinon.spy(TodoTracker.prototype, 'fail');
     const testGen = sinon.stub().rejects(new Error('boom'));
     const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
 
     const out = await supervisor.testGenerationNode(stateWithCode());
 
     expect(testGen.calledOnce).to.equal(true);
+    // Non-fatal contract preserved: terminal phase + no error/feedback channels.
+    const tg = out.testGeneration as { files: unknown[]; warnings?: string[] };
     expect(out.currentPhase).to.equal('complete');
-    expect(out.testGeneration).to.deep.equal(emptyResult);
+    expect(tg.files).to.deep.equal([]);
     expect(out.errors).to.equal(undefined);
     expect(out.validationFeedback).to.equal(undefined);
     expect(out.perFileFeedback).to.equal(undefined);
+    // But the failure is now reported honestly (warning + failed todo), not green.
+    expect(tg.warnings ?? []).to.satisfy(
+      (w: string[]) => w.some(s => /boom/.test(s)),
+    );
+    expect(failSpy.called, 'the test-gen todo must be marked failed').to.equal(true);
+  });
+
+  it('marks the todo failed when the agent returns no files WITH warnings (all dropped) (M2)', async () => {
+    const failSpy = sinon.spy(TodoTracker.prototype, 'fail');
+    const droppedResult = {
+      files: [],
+      explanation: '',
+      requirementsChecklist: [],
+      warnings: ['Dropped invalid test-plan item "b.ts": ...'],
+    };
+    const testGen = sinon.stub().resolves(droppedResult);
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
+
+    const out = await supervisor.testGenerationNode(stateWithCode());
+
+    expect(out.currentPhase).to.equal('complete');
+    expect(out.testGeneration).to.deep.equal(droppedResult);
+    expect(failSpy.called, 'a no-file result carrying warnings must fail the todo').to.equal(true);
+  });
+
+  it('stays complete (no fail) when the agent returns no files with NO warnings (intentional no-op) (M2)', async () => {
+    const failSpy = sinon.spy(TodoTracker.prototype, 'fail');
+    const testGen = sinon.stub().resolves(emptyResult);
+    const supervisor = buildSupervisorWithStubAgents(sinon.stub(), { testGenImpl: testGen });
+
+    const out = await supervisor.testGenerationNode(stateWithCode());
+
+    expect(out.currentPhase).to.equal('complete');
+    expect(out.testGeneration).to.deep.equal(emptyResult);
+    expect(failSpy.called, 'a warning-free empty result is an intentional no-op, not a failure')
+      .to.equal(false);
   });
 
   it('is reached once after the refinement loop exhausts and populates testGeneration', async () => {

--- a/test/supervisors/development-supervisor.spec.ts
+++ b/test/supervisors/development-supervisor.spec.ts
@@ -57,7 +57,7 @@ describe('resolveValidateImplEdge (R17.4)', () => {
   const baseState: ValidateImplEdgeState = {
     validationResult: { overallScore: 90 },
     iterationCount: 0,
-    codeGeneration: { crossFileIssues: [] },
+    codeGeneration: { crossFileIssues: [], files: [{}] },
   };
 
   it('returns __end__ when execute-no-op is present, even with iterations available', () => {
@@ -80,7 +80,7 @@ describe('resolveValidateImplEdge (R17.4)', () => {
       ...baseState,
       validationResult: { overallScore: 50 },
       iterationCount: 0,
-      codeGeneration: { crossFileIssues: [] },
+      codeGeneration: { crossFileIssues: [], files: [{}] },
     };
     expect(resolveValidateImplEdge(state)).to.equal('generateCode');
   });
@@ -92,6 +92,46 @@ describe('resolveValidateImplEdge (R17.4)', () => {
       iterationCount: 0,
       codeGeneration: {
         crossFileIssues: [{ issueType: 'compile-error' }],
+        files: [{}],
+      },
+    };
+    expect(resolveValidateImplEdge(state)).to.equal('generateCode');
+  });
+
+  it('does NOT loop on a plan-adherence-extra note alone (warn-only) when score is high (F-C)', () => {
+    const state: ValidateImplEdgeState = {
+      ...baseState,
+      validationResult: { overallScore: 95 },
+      iterationCount: 0,
+      codeGeneration: {
+        crossFileIssues: [{ issueType: 'plan-adherence-extra' }],
+        files: [{}],
+      },
+    };
+    expect(resolveValidateImplEdge(state)).to.equal('__end__');
+  });
+
+  it('ends the loop on a 0-file regeneration even below threshold (F-C 0-file guard)', () => {
+    const state: ValidateImplEdgeState = {
+      ...baseState,
+      validationResult: { overallScore: 10 },
+      iterationCount: 0,
+      codeGeneration: {
+        crossFileIssues: [{ issueType: 'plan-adherence-missing' }],
+        files: [], // 0 files: looping cannot help
+      },
+    };
+    expect(resolveValidateImplEdge(state)).to.equal('__end__');
+  });
+
+  it('still loops on a real compile-error even alongside a warn-only note (F-C)', () => {
+    const state: ValidateImplEdgeState = {
+      ...baseState,
+      validationResult: { overallScore: 95 },
+      iterationCount: 0,
+      codeGeneration: {
+        crossFileIssues: [{ issueType: 'plan-adherence-extra' }, { issueType: 'compile-error' }],
+        files: [{}],
       },
     };
     expect(resolveValidateImplEdge(state)).to.equal('generateCode');
@@ -106,7 +146,7 @@ describe('resolveValidateImplEdge (R17.4)', () => {
       ...baseState,
       validationResult: { overallScore: 50 },
       iterationCount: 3, // MAX_ITERATIONS
-      codeGeneration: { crossFileIssues: [] },
+      codeGeneration: { crossFileIssues: [], files: [{}] },
     };
     expect(resolveValidateImplEdge(state)).to.equal('__end__');
   });

--- a/test/supervisors/development-supervisor.spec.ts
+++ b/test/supervisors/development-supervisor.spec.ts
@@ -355,6 +355,25 @@ describe('DevelopmentSupervisor public file helpers (v9b.1)', () => {
     expect(await fs.readFile(path.join(scratch, 'src/a.ts'), 'utf-8')).to.equal('A\n');
   });
 
+  it('dedupes files by relativePath, keeping the last (test-gen) writer (F-D)', async () => {
+    const generate = sinon.stub();
+    const supervisor = buildSupervisorWithStubAgents(generate);
+    const state = mkDevState({
+      ...baseValidInputFragment,
+      codeGeneration: mkCodeGenResult([mkFile('src/shared.ts', 'CODE-GEN\n')]),
+      testGeneration: {
+        files: [mkFile('src/shared.ts', 'TEST-GEN\n')],
+        explanation: '',
+        requirementsChecklist: [],
+      },
+    });
+
+    const written = await supervisor.writeToChtCore(state, scratch);
+
+    expect(written).to.deep.equal(['src/shared.ts']); // one entry, not double-listed
+    expect(await fs.readFile(path.join(scratch, 'src/shared.ts'), 'utf-8')).to.equal('TEST-GEN\n');
+  });
+
   it('clearStaging removes the staging directory and tolerates missing dirs', async () => {
     const generate = sinon.stub();
     const supervisor = buildSupervisorWithStubAgents(generate);


### PR DESCRIPTION
## Summary

Closes #8.

Integrates the Test Generation Layer into the Development Supervisor, fulfilling the core requirement of issue #8: the supervisor now orchestrates both code generation **and** test generation using LangGraph.

- Adds a `generateTests` node to the LangGraph workflow, wired after `validateImpl` and outside the refinement loop, so test generation runs exactly once on the final accepted code
- Adds `TestGenerationAgent` (wrapping a pluggable `TestGenModuleRegistry`) with a `claude-api` module that produces test files in-memory
- Adds `TestGenerationResult` type and `test-generation` phase to `DevelopmentState`
- Adds a semantic-correctness gate (planted-bug fixtures) that spawn-executes an emitted spec to prove it fails on buggy source and passes on fixed source
- Removes the legacy `TestEnvironmentAgent` stub that was standing in for this layer
- Test-gen failure is non-fatal — the workflow proceeds to HC2 even if test generation fails
- `resolveValidateImplEdge` now distinguishes warn-only plan-adherence notes from blocking issues, and ends cleanly on 0-file runs

## What changed vs the original `8-create-development-supervisor` branch

The original branch had an early, simpler version of the supervisor with the test layer stubbed out. This PR builds on top of the now-merged Code Generation Layer (#62) and brings in the full test-generation implementation, keeping the refinement loop and all hardening from main.

## Test plan

- `npm test` — 1146 passing
- `npm run build` — clean build
- `npm run lint` — clean (advisory)

## Design notes

- Test-gen output never feeds the validation score or refinement loop
- The `generateTests` node name intentionally differs from the `testGeneration` state channel (LangGraph forbids node names that collide with state channels)
- Tool use is gated on `LLMProvider.honorsCustomTools`; the CLI path disables tools to keep it capturable and prevent out-of-band writes