### PR TITLE
feat(#47): add retry logic with exponential backoff to Claude CLI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ PIPELINE_CONCURRENCY=4
 # CLAUDE_CLI_TIMEOUT=300000
 # CLAUDE_CLI_MAX_TURNS=1
 # CLAUDE_CLI_SKIP_PERMISSIONS=true
+# Automatic retries (with 1s/2s/4s exponential backoff) for transient timeouts. Default: 3. Set 0 to disable.
+# CLAUDE_CLI_MAX_RETRIES=3
 
 # ── API path (only used when LLM_PROVIDER is unset) ──────────────────────
 # Anthropic API key

--- a/src/llm/providers/claude-cli.ts
+++ b/src/llm/providers/claude-cli.ts
@@ -40,7 +40,68 @@ export interface ClaudeCLIConfig {
   maxTokens?: number;
   /** Pass --dangerously-skip-permissions to the CLI. Default: true (preserves prior behavior). */
   skipPermissions?: boolean;
+  /**
+   * Maximum number of automatic retries for transient failures (default: 3, or
+   * the `CLAUDE_CLI_MAX_RETRIES` env var). 0 disables retries. Only transient
+   * errors are retried — see {@link isRetryableCLIError}.
+   */
+  maxRetries?: number;
+  /**
+   * Base delay (ms) for exponential backoff between retries (default: 1000, so
+   * 1s / 2s / 4s). Mainly a testing/tuning seam; production should leave the
+   * default.
+   */
+  retryBaseDelayMs?: number;
 }
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
+
+/** Resolve to a non-negative integer, falling back to `fallback` on garbage. */
+const toRetryCount = (value: number, fallback: number): number => {
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return Math.floor(value);
+};
+
+/**
+ * Resolve the retry budget from explicit config, then the
+ * `CLAUDE_CLI_MAX_RETRIES` env var, then the default.
+ */
+const resolveMaxRetries = (config: ClaudeCLIConfig): number => {
+  if (typeof config.maxRetries === 'number') {
+    return toRetryCount(config.maxRetries, DEFAULT_MAX_RETRIES);
+  }
+  const fromEnv = process.env.CLAUDE_CLI_MAX_RETRIES;
+  if (fromEnv !== undefined && fromEnv !== '') {
+    return toRetryCount(Number.parseInt(fromEnv, 10), DEFAULT_MAX_RETRIES);
+  }
+  return DEFAULT_MAX_RETRIES;
+};
+
+/** Promise-based sleep used between retry attempts. */
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Decide whether a failed CLI invocation is worth retrying.
+ *
+ * Only *timeouts* are retried: they are the transient/network failure this
+ * provider surfaces, and a fresh spawn often succeeds. Deliberately NOT retried:
+ * - Rate-limit / usage-limit and auth notices — the provider classifies these
+ *   as batch-fatal (see {@link parseResponse} / `isBatchFatalError`) so the
+ *   pipeline stops fast instead of burning backoff against an exhausted quota
+ *   or a login that won't fix itself in seconds.
+ * - Config errors (`ENOENT`/`EACCES`) — retrying a missing/unexecutable binary
+ *   is pointless.
+ * - Deterministic non-zero exits / empty results — retrying would mask, not
+ *   fix, a real failure.
+ */
+export function isRetryableCLIError(error: unknown): boolean {
+  return /timed out after/i.test(describeError(error));
+}
+
+/** Render any thrown value as a log-safe string. */
+const describeError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
 /**
  * Tools to deny when running the CLI in text-only mode.
@@ -106,6 +167,8 @@ export const createClaudeCLIProvider = (config: ClaudeCLIConfig = {}): LLMProvid
   const maxTurns = config.maxTurns ?? 20; // Multiple turns needed - test files can need 15+
   const modelName = config.model ?? 'claude-cli';
   const skipPermissions = config.skipPermissions ?? true;
+  const maxRetries = resolveMaxRetries(config);
+  const retryBaseDelayMs = config.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
   // Note: CLI doesn't support temperature/maxTokens directly via flags
   // These would be handled by account settings or model defaults
 
@@ -248,6 +311,54 @@ export const createClaudeCLIProvider = (config: ClaudeCLIConfig = {}): LLMProvid
   };
 
   /**
+   * Execute the CLI with automatic retries + exponential backoff for transient
+   * failures (see {@link isRetryableCLIError}). Wraps only the spawn/transport
+   * step: response parsing (and its batch-fatal rate-limit/auth classification)
+   * runs downstream in `invoke`, deliberately outside the retry loop.
+   */
+  const canRetry = (error: unknown, attempt: number): boolean =>
+    attempt < maxRetries && isRetryableCLIError(error);
+
+  // Log the transient failure and wait out the exponential backoff (1s/2s/4s
+  // at the default base) before the next attempt.
+  const backoffAfterFailure = async (error: unknown, attempt: number): Promise<void> => {
+    const delay = retryBaseDelayMs * 2 ** attempt;
+    console.log(
+      `[Claude CLI] Attempt ${attempt + 1}/${maxRetries + 1} failed (${describeError(error)}); retrying in ${delay}ms...`
+    );
+    await sleep(delay);
+  };
+
+  // One attempt. Resolves the CLI stdout on success. On a retryable failure with
+  // attempts remaining, backs off and resolves `null` to signal "try again";
+  // otherwise rethrows. (executeCLI only ever resolves a string, so `null` is an
+  // unambiguous retry sentinel.)
+  const attemptExecute = async (
+    prompt: string,
+    options: InvokeOptions | undefined,
+    attempt: number,
+  ): Promise<string | null> => {
+    try {
+      return await executeCLI(prompt, options);
+    } catch (error) {
+      if (!canRetry(error, attempt)) throw error;
+      await backoffAfterFailure(error, attempt);
+      return null;
+    }
+  };
+
+  const executeCLIWithRetry = async (prompt: string, options?: InvokeOptions): Promise<string> => {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const stdout = await attemptExecute(prompt, options, attempt);
+      if (stdout !== null) return stdout;
+    }
+    // Unreachable: the final attempt either returns stdout or rethrows (canRetry
+    // is false once attempt === maxRetries), so the loop never falls through.
+    /* istanbul ignore next -- defensive, loop always returns or throws above */
+    throw new Error('Claude CLI retry loop exhausted without a result');
+  };
+
+  /**
    * Parse CLI JSON response
    */
   const parseResponse = (stdout: string): CLIResponse => {
@@ -310,7 +421,7 @@ export const createClaudeCLIProvider = (config: ClaudeCLIConfig = {}): LLMProvid
    * Invoke with a simple prompt
    */
   const invoke = async (prompt: string, options?: InvokeOptions): Promise<LLMResponse> => {
-    const stdout = await executeCLI(prompt, options);
+    const stdout = await executeCLIWithRetry(prompt, options);
     const parsed = parseResponse(stdout);
 
     if (parsed.is_error) {

--- a/test/llm/providers/claude-cli.spec.ts
+++ b/test/llm/providers/claude-cli.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { EventEmitter } from 'events';
 import { LLMProvider } from '../../../src/llm/types';
-import { DISALLOWED_TOOLS } from '../../../src/llm/providers/claude-cli';
+import { DISALLOWED_TOOLS, isRetryableCLIError } from '../../../src/llm/providers/claude-cli';
 import { isBatchFatalError } from '../../../src/llm/rate-limit';
 
 const proxyquire = require('proxyquire').noCallThru();
@@ -392,5 +392,123 @@ describe('createClaudeCLIProvider — limit/auth classification & error paths', 
     const { provider } = loadProvider([{ stdout: 'noise {"type":"result", not valid}', closeCode: 0 }]);
     const res = await provider.invoke('x');
     expect(res.content).to.include('type');
+  });
+});
+
+describe('createClaudeCLIProvider — retry logic (#47)', () => {
+  type ProcEvents = Array<{
+    stdout?: string;
+    stderr?: string;
+    closeCode?: number | null;
+    errorCode?: string;
+    delay?: number;
+  }>;
+
+  /**
+   * Build a provider whose Nth spawn yields `perAttempt[N]` (the last entry is
+   * reused once exhausted). An empty events array means the fake process never
+   * closes, so `executeCLI`'s (small) timeout fires — the retryable failure the
+   * retry loop is built to handle.
+   */
+  const loadProviderSeq = (
+    perAttempt: ProcEvents[],
+    config: Record<string, unknown>
+  ): { provider: LLMProvider; spawnCount: () => number } => {
+    let call = 0;
+    const spawnStub = sinon.stub().callsFake(() => {
+      const events = perAttempt[Math.min(call, perAttempt.length - 1)];
+      call += 1;
+      return buildFakeProc(events).proc;
+    });
+    const mod = proxyquire('../../../src/llm/providers/claude-cli', {
+      'node:child_process': { spawn: spawnStub },
+    });
+    return {
+      provider: mod.createClaudeCLIProvider(config) as LLMProvider,
+      spawnCount: () => call,
+    };
+  };
+
+  const rejection = async (p: Promise<unknown>): Promise<Error> => {
+    try {
+      await p;
+    } catch (e) {
+      return e as Error;
+    }
+    throw new Error('expected promise to reject');
+  };
+
+  describe('isRetryableCLIError classification', () => {
+    it('retries timeout errors', () => {
+      expect(isRetryableCLIError(new Error('Claude CLI timed out after 600000ms'))).to.equal(true);
+    });
+
+    it('does not retry rate-limit / usage-limit errors (batch-fatal by design)', () => {
+      expect(isRetryableCLIError(new Error("Claude CLI error: You've hit your usage limit"))).to.equal(false);
+    });
+
+    it('does not retry auth errors', () => {
+      expect(isRetryableCLIError(new Error('Claude CLI error: Invalid authentication'))).to.equal(false);
+    });
+
+    it('does not retry missing-binary (ENOENT) errors', () => {
+      expect(isRetryableCLIError(new Error('Claude Code CLI not found at "claude"'))).to.equal(false);
+    });
+
+    it('does not retry a generic non-zero exit', () => {
+      expect(isRetryableCLIError(new Error('Claude CLI exited with code 1: boom'))).to.equal(false);
+    });
+
+    it('handles non-Error values without throwing', () => {
+      expect(isRetryableCLIError('some string')).to.equal(false);
+      expect(isRetryableCLIError(undefined)).to.equal(false);
+    });
+  });
+
+  it('retries a timed-out attempt and succeeds on the next one', async () => {
+    const { provider, spawnCount } = loadProviderSeq(
+      [[], [{ stdout: cliResultJson({ result: 'recovered' }), closeCode: 0 }]],
+      { timeout: 20, maxRetries: 3, retryBaseDelayMs: 1 }
+    );
+    const result = await provider.invoke('p');
+    expect(result.content).to.equal('recovered');
+    expect(spawnCount()).to.equal(2); // one failure + one retry
+  });
+
+  it('gives up after maxRetries and throws the last timeout error', async () => {
+    const { provider, spawnCount } = loadProviderSeq(
+      [[]], // every attempt times out
+      { timeout: 15, maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const err = await rejection(provider.invoke('p'));
+    expect(err.message).to.match(/timed out after/);
+    expect(spawnCount()).to.equal(3); // initial attempt + 2 retries
+  });
+
+  it('does not retry a non-retryable batch-fatal error (single attempt)', async () => {
+    const { provider, spawnCount } = loadProviderSeq(
+      [[{ stdout: "You've hit your usage limit · resets at 5pm", closeCode: 0 }]],
+      { maxRetries: 3, retryBaseDelayMs: 1 }
+    );
+    const err = await rejection(provider.invoke('p'));
+    expect(isBatchFatalError(err.message)).to.equal(true);
+    expect(spawnCount()).to.equal(1); // classified fatal downstream, never retried
+  });
+
+  it('honors CLAUDE_CLI_MAX_RETRIES=0 (retries disabled) from the environment', async () => {
+    const prev = process.env.CLAUDE_CLI_MAX_RETRIES;
+    process.env.CLAUDE_CLI_MAX_RETRIES = '0';
+    try {
+      const { provider, spawnCount } = loadProviderSeq(
+        [[]], // times out
+        { timeout: 15, retryBaseDelayMs: 1 } // no maxRetries in config -> env wins
+      );
+      const err = await rejection(provider.invoke('p'));
+      expect(err.message).to.match(/timed out after/);
+      expect(spawnCount()).to.equal(1); // env disabled retries
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_CLI_MAX_RETRIES;
+      else process.env.CLAUDE_CLI_MAX_RETRIES = prev;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #47.

Adds automatic retry with exponential backoff to the Claude CLI provider (`src/llm/providers/claude-cli.ts`) for transient failures, improving reliability against network blips / timeouts.

- Wraps the CLI spawn/transport step in a retry loop: **1s → 2s → 4s** backoff
- Configurable via a new `maxRetries` config option and the **`CLAUDE_CLI_MAX_RETRIES`** env var (default `3`, `0` disables)
- Logs each retry attempt (`Attempt N/M failed (...); retrying in Xms...`)
- Exposes `isRetryableCLIError()` (pure, exported) so the classification is unit-testable in isolation

## Deliberate deviation from the ticket — please note

The ticket lists "Retry on rate limit errors (429)". I intentionally **did not** retry rate-limit/auth notices, because this codebase already classifies them as **batch-fatal** (`isBatchFatalError` in `rate-limit.ts`, used by `parseResponse` + `run-pipeline`) so the batch stops *fast* rather than flagging a PR on exhausted quota. Retrying a usage-limit with a few seconds of backoff is futile (quota won't reset) and would actively undermine that documented fast-stop design.

So the retry scope is: **timeouts** (the genuine transient/network failure this provider surfaces). Not retried, by design: rate-limit/auth (batch-fatal), config errors (`ENOENT`/`EACCES`), and deterministic non-zero exits. Response parsing stays *outside* the retry loop, so batch-fatal classification is unchanged. Happy to widen the scope if the squad prefers the literal 429-retry behavior.

## Acceptance criteria

- [x] Retry logic implemented in `src/llm/providers/claude-cli.ts`
- [x] Configurable via `CLAUDE_CLI_MAX_RETRIES` env variable
- [x] Exponential backoff working (1s / 2s / 4s)
- [x] Unit tests added
- [~] "Retry on rate limit (429)" — deliberately excluded (batch-fatal by design; see above)

## Test plan

- `npm run build` — clean
- `npm run lint` — clean
- `npm test` — 1011 passing (+10 new)
- `npm run test:coverage` — all floors pass; `claude-cli.ts` at 96% statements / 90% branches